### PR TITLE
Mkfehmdir tests 2

### DIFF
--- a/matlab_archive/test/test_appendzone.m
+++ b/matlab_archive/test/test_appendzone.m
@@ -1,0 +1,51 @@
+% test appendzone
+
+%% appendzone jdf3d_p12d_g981
+test_against_fixture('jdf3d_p12d_g981', 'p12d_g981');
+
+
+%% appendzone jdf3d_deep_p11ani
+test_against_fixture('jdf3d_deep_p11ani', 'p11d600efto_GBv10BBv10_g981');
+
+
+%% appendzone np2d_cond
+test_against_fixture('np2d_cond', 'cond');
+
+
+%% appendzone np2d_p11
+test_against_fixture('np2d_p11', 'run');
+
+
+%% appendzone np3d_cond
+test_against_fixture('np3d_cond', 'run');
+
+
+%% appendzone np3d_p11
+test_against_fixture('np3d_p11', 'run');
+
+
+function test_against_fixture(fixture_name, run_name)
+    initial_dir = pwd;
+    fixture_dir = fullfile(initial_dir, 'fixtures', fixture_name);
+    test_dir = fullfile(tempdir, strcat('test_appendzone__', fixture_name));
+
+    if isfolder(test_dir)
+        rmdir(test_dir, 's');
+    end
+
+    try
+        mkdir(test_dir);
+        cd(test_dir);
+
+        appendzone('top', 'test.zone', fixture_dir);
+        appendzone('bottom', 'test.zone', test_dir);
+
+        assert_files_match('test.zone', fullfile(fixture_dir, strcat(run_name, '.zone')));
+    catch e
+        cd(initial_dir);
+        rethrow(e);
+    end
+
+    rmdir(test_dir, 's');
+    cd(initial_dir);
+end

--- a/matlab_archive/test/test_appendzone.m
+++ b/matlab_archive/test/test_appendzone.m
@@ -36,9 +36,11 @@ function test_against_fixture(fixture_name, run_name)
     try
         mkdir(test_dir);
         cd(test_dir);
-
-        appendzone('top', 'test.zone', fixture_dir);
-        appendzone('bottom', 'test.zone', test_dir);
+        copyfile(fullfile(fixture_dir, strcat(run_name, '_outside.zone')), '.');
+        copyfile(fullfile(fixture_dir, strcat(run_name, '_material.zone')), strcat(run_name, '.zone'));
+        
+        appendzone('top');
+        appendzone('bottom', 'test.zone');
 
         assert_files_match('test.zone', fullfile(fixture_dir, strcat(run_name, '.zone')));
     catch e

--- a/matlab_archive/test/test_avs2fin.m
+++ b/matlab_archive/test/test_avs2fin.m
@@ -1,10 +1,10 @@
 % test avs2fin
 
-%% avs2fin np2d_cond
-test_against_fixture('np2d_cond', 'avs2fin_fixture.fin');
+%% avs2fin jdf2d_p12
+test_against_fixture('jdf2d_p12', 'p12', 'avs2fin_fixture.fin');
 
 
-function test_against_fixture(fixture_name, output_fixture_filename)
+function test_against_fixture(fixture_name, run_name, output_fixture_filename)
     initial_dir = pwd;
     fixture_dir = fullfile(initial_dir, 'fixtures', fixture_name);
     test_dir = fullfile(tempdir, strcat('test_avs2fin__', fixture_name));
@@ -16,8 +16,11 @@ function test_against_fixture(fixture_name, output_fixture_filename)
     try
         mkdir(test_dir);
         cd(test_dir);
+        
+        copyfile(fullfile(fixture_dir, strcat(run_name, '.ini')), '.');
+        copyfile(fullfile(fixture_dir, '*_sca_node.avs'), '.');
 
-        avs2fin('test.fin', fixture_dir);
+        avs2fin('test.fin');
 
         assert_files_match('test.fin', fullfile(fixture_dir, output_fixture_filename));
     catch e

--- a/matlab_archive/test/test_avs2fin.m
+++ b/matlab_archive/test/test_avs2fin.m
@@ -1,0 +1,30 @@
+% test avs2fin
+
+%% avs2fin np2d_cond
+test_against_fixture('np2d_cond', 'avs2fin_fixture.fin');
+
+
+function test_against_fixture(fixture_name, output_fixture_filename)
+    initial_dir = pwd;
+    fixture_dir = fullfile(initial_dir, 'fixtures', fixture_name);
+    test_dir = fullfile(tempdir, strcat('test_avs2fin__', fixture_name));
+
+    if isfolder(test_dir)
+        rmdir(test_dir, 's');
+    end
+
+    try
+        mkdir(test_dir);
+        cd(test_dir);
+
+        avs2fin('test.fin', fixture_dir);
+
+        assert_files_match('test.fin', fullfile(fixture_dir, output_fixture_filename));
+    catch e
+        cd(initial_dir);
+        rethrow(e);
+    end
+
+    rmdir(test_dir, 's');
+    cd(initial_dir);
+end

--- a/matlab_archive/test/test_fin2ini.m
+++ b/matlab_archive/test/test_fin2ini.m
@@ -31,7 +31,7 @@ function test_against_fixture(fixture_name, output_fixture_filename, useiap_outs
 
         fin2ini('test.ini', fixture_dir, useiap_outsidezone);
 
-        assert_files_match('test.dat', fullfile(fixture_dir, output_fixture_filename));
+        assert_files_match('test.ini', fullfile(fixture_dir, output_fixture_filename));
     catch e
         cd(initial_dir);
         rethrow(e);

--- a/matlab_archive/test/test_fin2ini.m
+++ b/matlab_archive/test/test_fin2ini.m
@@ -1,0 +1,42 @@
+% test fin2ini
+
+%% fin2ini np2d_cond
+test_against_fixture('np2d_cond', 'fin2ini_fixture_1.ini', 0);
+
+
+%% fin2ini np2d_cond iap_outsidezone
+test_against_fixture('np2d_cond', 'fin2ini_fixture_2.ini', 1);
+
+
+%% fin2ini jdf2d_p12
+test_against_fixture('jdf2d_p12', 'fin2ini_fixture_1.ini', 0);
+
+
+%% fin2ini jdf2d_p12 iap_outsidezone
+test_against_fixture('jdf2d_p12', 'fin2ini_fixture_2.ini', 1);
+
+
+function test_against_fixture(fixture_name, output_fixture_filename, useiap_outsidezone)
+    initial_dir = pwd;
+    fixture_dir = fullfile(initial_dir, 'fixtures', fixture_name);
+    test_dir = fullfile(tempdir, strcat('test_fin2ini__', fixture_name));
+
+    if isfolder(test_dir)
+        rmdir(test_dir, 's');
+    end
+
+    try
+        mkdir(test_dir);
+        cd(test_dir);
+
+        fin2ini('test.ini', fixture_dir, useiap_outsidezone);
+
+        assert_files_match('test.dat', fullfile(fixture_dir, output_fixture_filename));
+    catch e
+        cd(initial_dir);
+        rethrow(e);
+    end
+
+    rmdir(test_dir, 's');
+    cd(initial_dir);
+end

--- a/matlab_archive/test/test_fin2ini2.m
+++ b/matlab_archive/test/test_fin2ini2.m
@@ -1,0 +1,34 @@
+% test fin2ini2
+
+%% fin2ini2 np2d_cond
+test_against_fixture('np2d_cond', 'fin2ini2_fixture.ini');
+
+
+%% fin2ini2 jdf2d_p12
+test_against_fixture('jdf2d_p12', 'fin2ini2_fixture.ini');
+
+
+function test_against_fixture(fixture_name, output_fixture_filename)
+    initial_dir = pwd;
+    fixture_dir = fullfile(initial_dir, 'fixtures', fixture_name);
+    test_dir = fullfile(tempdir, strcat('test_fin2ini2__', fixture_name));
+
+    if isfolder(test_dir)
+        rmdir(test_dir, 's');
+    end
+
+    try
+        mkdir(test_dir);
+        cd(test_dir);
+
+        fin2ini2('test.ini', fixture_dir);
+
+        assert_files_match('test.dat', fullfile(fixture_dir, output_fixture_filename));
+    catch e
+        cd(initial_dir);
+        rethrow(e);
+    end
+
+    rmdir(test_dir, 's');
+    cd(initial_dir);
+end

--- a/matlab_archive/test/test_fin2ini2.m
+++ b/matlab_archive/test/test_fin2ini2.m
@@ -23,7 +23,7 @@ function test_against_fixture(fixture_name, output_fixture_filename)
 
         fin2ini2('test.ini', fixture_dir);
 
-        assert_files_match('test.dat', fullfile(fixture_dir, output_fixture_filename));
+        assert_files_match('test.ini', fullfile(fixture_dir, output_fixture_filename));
     catch e
         cd(initial_dir);
         rethrow(e);

--- a/matlab_archive/test/test_iap2ini.m
+++ b/matlab_archive/test/test_iap2ini.m
@@ -23,7 +23,7 @@ function test_against_fixture(fixture_name, output_fixture_filename)
 
         iap2ini('test.ini', fixture_dir);
 
-        assert_files_match('test.dat', fullfile(fixture_dir, output_fixture_filename));
+        assert_files_match('test.ini', fullfile(fixture_dir, output_fixture_filename));
     catch e
         cd(initial_dir);
         rethrow(e);

--- a/matlab_archive/test/test_iap2ini.m
+++ b/matlab_archive/test/test_iap2ini.m
@@ -1,0 +1,34 @@
+% test iap2ini
+
+%% iap2ini np2d_cond
+test_against_fixture('np2d_cond', 'iap2ini_fixture.ini');
+
+
+%% iap2ini jdf2d_p12
+test_against_fixture('jdf2d_p12', 'iap2ini_fixture.ini');
+
+
+function test_against_fixture(fixture_name, output_fixture_filename)
+    initial_dir = pwd;
+    fixture_dir = fullfile(initial_dir, 'fixtures', fixture_name);
+    test_dir = fullfile(tempdir, strcat('test_iap2ini__', fixture_name));
+
+    if isfolder(test_dir)
+        rmdir(test_dir, 's');
+    end
+
+    try
+        mkdir(test_dir);
+        cd(test_dir);
+
+        iap2ini('test.ini', fixture_dir);
+
+        assert_files_match('test.dat', fullfile(fixture_dir, output_fixture_filename));
+    catch e
+        cd(initial_dir);
+        rethrow(e);
+    end
+
+    rmdir(test_dir, 's');
+    cd(initial_dir);
+end


### PR DESCRIPTION
Second batch of tests for utilities that support mkfehmdir. The strategy here is to test all functions that modify files in some way, but not test mkfehmdir as a whole - since the only added benefit there is testing Matlab's copyfile functionality, which is unnecessary.

This PR has the remaining utilities missed in the first PR (#10) - `iap2ini`, `fin2ini`, `avs2fin`, `appendzone`. For fin2ini I've tried to test the `useiap` functionality, but in the cases I've found the iap file has the same values as that in the .fin. I think we included this out of paranoia to avoid drift, which is fine, just makes it hard to test.

No surprises on the outputs in this one, everything matches as expected!