### PR TITLE
Create python package and config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,19 @@ This toolkit consists of utilities and convenience functions to enable fast and 
 
 ## Work in progress
 This toolkit is in the early stages of development and is not yet in working order. This page will be updated when an initial release is ready. Work to date is focused on collating and testing previous Matlab versions of the code.
+
+## Installation and use
+TODO: complete this section when we have basic working functionality on some of the tools.
+
+## Development
+The toolkit and its dependencies can be installed for development purposes. Simply clone the repository, then run the following commands:
+
+**Important** we strongly recommend installing this into a virtual environment (TODO: provide a link or tutorial explaining how to do this).
+
+```bash
+pip install -e ".[all]"
+```
+After this, run the tests to check everything is running correctly:
+```bash
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools >= 60",
+    "wheel >= 0.37.1",
+]
+build-backend = 'setuptools.build_meta'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,57 @@
+[metadata]
+name = fehm_toolkit
+version = 0.1
+description = Utilities and convenience functions for fast and efficient use of FEHM and LaGriT
+long_description = file: README.md
+long_description_content_type = text/markdown; charset=UTF-8
+url = https://github.com/UCSC-Hydrogeology/fehmToolkit
+author = Dustin Winslow
+author_email = dmwinslow@gmail.com
+license = BSD 3-clause
+license_file = LICENSE
+keywords = FEHM, LaGriT
+classifiers =
+    Development Status :: 1 - Planning
+    Intended Audience :: Science/Research
+    Natural Language :: English
+    Operating System :: MacOS :: MacOS X
+    Operating System :: POSIX :: Linux
+    Operating System :: Microsoft :: Windows
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.9
+    Topic :: Scientific/Engineering :: Hydrology
+project_urls = 
+    Source = https://github.com/UCSC-Hydrogeology/fehmToolkit
+    Tracker = https://github.com/UCSC-Hydrogeology/fehmToolkit/issues
+
+[options]
+zip_safe = False
+packages = find:
+platforms = any
+include_package_data = True
+install_requires =
+    numpy>1.22,<1.23
+python_requires = >=3.9
+
+[options.extras_require]
+test =
+    pytest >= 6.2.5
+all =
+    %(test)s
+
+[options.packages.find]
+exclude =
+    test
+    test.*
+
+[pep8]
+max-line-length = 120
+exclude = .git,__pycache__,venv,.venv
+
+[flake8]
+max-line-length = 120
+exclude = .git,__pycache__,venv,.venv
+
+[tool:pytest]
+addopts = --doctest-modules
+

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+import setuptools
+
+if __name__ == "__main__":
+    setuptools.setup()


### PR DESCRIPTION
This contains an empty python package and all of the initial configuration files necessary for other to use and develop on it. Currently the only external dependencies are `numpy` and `pytest`, though these can be expanded in the future.

I've expanded the readme to include the basic instructions on how to install these, though it currently assumes you already have a working python installation and virtual environment - instructions on those will need to come separately.