### PR TITLE
Configure github actions to run python tests

### DIFF
--- a/.github/workflows/ci_pytest.yaml
+++ b/.github/workflows/ci_pytest.yaml
@@ -1,0 +1,33 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          pip install -e ".[all]"
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Test with pytest
+        run: |
+          pytest

--- a/.github/workflows/ci_pytest.yaml
+++ b/.github/workflows/ci_pytest.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Set up Github Actions to automatically run python tests on all branches. This will provide a notification on all PRs showing whether the tests pass or fail.

I've set this up to run on a combination of python versions (3.9 and 3.10) and systems (Windows/Mac/Linux), so we can test our code across all of them. Currently we only have a single test being run, but as we add more they will automatically be tested on all of these options.

You can see this in action on this PR if you look below under "All checks have passed" - this shows the results of each of the test runs. Once this PR is merged, all future PRs will have this section as well.