### PR TITLE
Refactor grid to separate reading files from constructing nodes

### DIFF
--- a/fehm_toolkit/fehm_objects/element.py
+++ b/fehm_toolkit/fehm_objects/element.py
@@ -12,4 +12,4 @@ class Element:
     def from_fehm_line(cls, raw_line: str) -> 'Element':
         split_line = raw_line.strip().split()
         n, nodes = split_line[0], split_line[1:]
-        return cls(number=int(n), connectivity=len(nodes), nodes=(int(node) for node in nodes))
+        return cls(number=int(n), connectivity=len(nodes), nodes=tuple(int(node) for node in nodes))

--- a/fehm_toolkit/fehm_objects/grid.py
+++ b/fehm_toolkit/fehm_objects/grid.py
@@ -8,9 +8,13 @@ from .node import Node
 class Grid:
     """Class representing a mesh or grid object."""
 
-    def __init__(self, nodes_by_number: dict, elements_by_number: dict):
-        self._nodes_by_number = nodes_by_number or {}
-        self._elements_by_number = elements_by_number or {}
+    def __init__(
+        self,
+        nodes_by_number: dict[int, Node],
+        elements_by_number: dict[int, Element],
+    ):
+        self._nodes_by_number = nodes_by_number
+        self._elements_by_number = elements_by_number
 
     def node(self, number: int) -> Node:
         try:
@@ -49,11 +53,16 @@ class Grid:
 
 def _construct_nodes_lookup(
     coordinates_by_number,
-) -> dict[int, Node]: 
+) -> dict[int, Node]:
     return {number: Node(number, x, y, z) for number, (x, y, z) in coordinates_by_number.items()}
 
 
 def read_fehm(fehm_file: Path) -> tuple[dict, dict]:
+    """Read FEHM-formatted files (.fehm)
+
+    Read coordinates and elements and return as dictionaries keyed by number.
+    """
+
     coordinates_by_number = None
     elements_by_number = None
 
@@ -72,9 +81,9 @@ def read_fehm(fehm_file: Path) -> tuple[dict, dict]:
             next(f)  # throw away extra line after block
 
     if not coordinates_by_number:
-        raise ValueError(f'Invalid fehm_file ({fehm_file}, no coordinate data found')
+        raise ValueError(f'Invalid fehm_file ({fehm_file}), no coordinate data found')
     if not elements_by_number:
-        raise ValueError(f'Invalid fehm_file ({fehm_file}, no element data found')
+        raise ValueError(f'Invalid fehm_file ({fehm_file}), no element data found')
 
     return coordinates_by_number, elements_by_number
 

--- a/fehm_toolkit/fehm_objects/grid.py
+++ b/fehm_toolkit/fehm_objects/grid.py
@@ -1,4 +1,5 @@
-from typing import TextIO
+from pathlib import Path
+from typing import Optional, TextIO
 
 from .element import Element
 from .node import Node
@@ -32,44 +33,68 @@ class Grid:
         return len(self._elements_by_number)
 
     @classmethod
-    def from_fehm(cls, fehm_file) -> 'Grid':
-        nodes_by_number = None
-        elements_by_number = None
-
-        with open(fehm_file) as f:
-            while True:
-                block_name = next(f).strip()
-
-                if block_name == 'coor':
-                    nodes_by_number = cls._read_coor(f)
-                elif block_name == 'elem':
-                    elements_by_number = cls._read_elem(f)
-                elif block_name == 'stop':
-                    break
-                else:
-                    raise NotImplementedError(f'No parser for block type "{block_name}"')
-
-                next(f)  # throw away extra line after block
+    def from_files(
+        cls,
+        fehm_file: Path,
+        *,
+        material_zone_file: Optional[Path] = None,
+        outside_zone_file: Optional[Path] = None,
+        area_file: Optional[Path] = None,
+    ) -> 'Grid':
+        coordinates_by_number, elements_by_number = read_fehm(fehm_file)
+        nodes_by_number = _construct_nodes_lookup(coordinates_by_number)
 
         return cls(nodes_by_number=nodes_by_number, elements_by_number=elements_by_number)
 
-    @classmethod
-    def _read_coor(cls, open_file: TextIO) -> dict[int, Node]:
-        n_nodes = int(next(open_file))
 
-        nodes_by_number = {}
-        for i in range(n_nodes):
-            node = Node.from_fehm_line(next(open_file))
-            nodes_by_number[node.number] = node
+def _construct_nodes_lookup(
+    coordinates_by_number,
+) -> dict[int, Node]: 
+    return {number: Node(number, x, y, z) for number, (x, y, z) in coordinates_by_number.items()}
 
-        return nodes_by_number
 
-    @classmethod
-    def _read_elem(cls, open_file: TextIO) -> dict[int, Node]:
-        n_elements = int(next(open_file).strip().split()[1])
+def read_fehm(fehm_file: Path) -> tuple[dict, dict]:
+    coordinates_by_number = None
+    elements_by_number = None
 
-        elements_by_number = {}
-        for i in range(n_elements):
-            element = Element.from_fehm_line(next(open_file))
-            elements_by_number[element.number] = element
-        return elements_by_number
+    with open(fehm_file) as f:
+        while True:
+            block_name = next(f).strip()
+
+            if block_name == 'coor':
+                coordinates_by_number = _read_coor(f)
+            elif block_name == 'elem':
+                elements_by_number = _read_elem(f)
+            elif block_name == 'stop':
+                break
+            else:
+                raise NotImplementedError(f'No parser for block type "{block_name}"')
+            next(f)  # throw away extra line after block
+
+    if not coordinates_by_number:
+        raise ValueError(f'Invalid fehm_file ({fehm_file}, no coordinate data found')
+    if not elements_by_number:
+        raise ValueError(f'Invalid fehm_file ({fehm_file}, no element data found')
+
+    return coordinates_by_number, elements_by_number
+
+
+def _read_coor(open_file: TextIO) -> dict[int, tuple[float]]:
+    n_nodes = int(next(open_file))
+
+    coordinates_by_number = {}
+    for i in range(n_nodes):
+        number, x, y, z = next(open_file).strip().split()
+        coordinates_by_number[int(number)] = (float(x), float(y), float(z))
+
+    return coordinates_by_number
+
+
+def _read_elem(open_file: TextIO) -> dict[int, Node]:
+    n_elements = int(next(open_file).strip().split()[1])
+
+    elements_by_number = {}
+    for i in range(n_elements):
+        element = Element.from_fehm_line(next(open_file))
+        elements_by_number[element.number] = element
+    return elements_by_number

--- a/fehm_toolkit/fehm_objects/node.py
+++ b/fehm_toolkit/fehm_objects/node.py
@@ -12,8 +12,3 @@ class Node:
     @property
     def coordinates(self) -> tuple[float]:
         return (self.x, self.y, self.z)
-
-    @classmethod
-    def from_fehm_line(cls, raw_line: str) -> 'Node':
-        n, x, y, z = raw_line.strip().split()
-        return cls(number=int(n), x=float(x), y=float(y), z=float(z))

--- a/test/fehm_objects/test_grid.py
+++ b/test/fehm_objects/test_grid.py
@@ -6,7 +6,7 @@ FIXTURE_DIR = Path(__file__).parent / 'fixtures'
 
 
 def test_ziggurat_from_fehm():
-    grid = Grid.from_fehm(FIXTURE_DIR / 'simple_pyramid.fehm')
+    grid = Grid.from_files(FIXTURE_DIR / 'simple_pyramid.fehm')
     assert grid.n_nodes == 5
     assert grid.n_elements == 2
     assert grid.element(2).number == 2


### PR DESCRIPTION
Refactor grid object to decouple the reading of files from node construction. This is to enable storing other values in the nodes (area is needed next for heatin).

This shouldn't cause any functional changes (as evidenced by the test still passing), just moving code around to make the next part easier to develop.