### PR TITLE
Create hfi reader for legacy configs

### DIFF
--- a/fehm_toolkit/config/heat_in.py
+++ b/fehm_toolkit/config/heat_in.py
@@ -1,0 +1,90 @@
+from pathlib import Path
+import re
+
+CRUSTAL_AGE_MODEL_KIND = 'crustal_age'
+
+CRUSTAL_AGE_MODEL_SIGNATURE = 'HFLX=@(x,y,z)A./AGE(x).^(.5)'
+AGE_SIGN_PATTERN = r'AGE=@\(x\)\(1\.\/\(SPREADRATE\.\*1E3\)\)\.\*\((-?)x\+X0\)'
+NUMERIC_PATTERN = r'(?:(?:\d+\.\d+)|(?:\.{0,1}\d+))(?:(?:e|E)-{0,1}\d+){0,1}'
+
+
+def read_legacy_config(hfi_file: Path) -> dict:
+    """Read legacy heatflux in files (.hfi)
+
+    This assumes a fairly specific format for these files, supporting only a few files with a specific structure.
+    """
+    processed_text = _read_and_process_hfi(hfi_file)
+
+    is_crustal_age_model = CRUSTAL_AGE_MODEL_SIGNATURE in processed_text
+    if is_crustal_age_model:
+        params = _get_crustal_age_model_parameters(processed_text, hfi_file)
+        return {
+            'heatflux': {
+                'model_kind': CRUSTAL_AGE_MODEL_KIND,
+                'model_params': params,
+            },
+        }
+
+    raise NotImplementedError(f'No model matched for {hfi_file}. File format not supported.')
+
+
+def _get_crustal_age_model_parameters(processed_text: str, hfi_file: Path) -> dict[str, float]:
+    return {
+        'crustal_age_sign': _get_crustal_age_sign(processed_text, hfi_file),
+        'spread_rate_mm_per_year': _get_spread_rate(processed_text, hfi_file),
+        'coefficient_MW': _get_heatflux_coefficient(processed_text, hfi_file),
+        'boundary_distance_to_ridge_m': _get_distance_to_ridge(processed_text, hfi_file),
+    }
+
+
+def _get_crustal_age_sign(processed_text: str, hfi_file: Path) -> int:
+    match = re.search(AGE_SIGN_PATTERN, processed_text)
+    if match is None:
+        raise NotImplementedError(
+            f'File ({hfi_file}) is a crustal age model, but no age function found.'
+        )
+    crustal_age_sign = -1 if match.group(1) == '-' else 1
+    return crustal_age_sign
+
+
+def _get_spread_rate(processed_text: str, hfi_file: Path) -> float:
+    match = re.search(fr'SPREADRATE=({NUMERIC_PATTERN})', processed_text)
+    if match is None:
+        raise NotImplementedError(f'File {hfi_file} is a crustal age model, but no SPREADRATE found.')
+    return float(match.group(1))
+
+
+def _get_heatflux_coefficient(processed_text: str, hfi_file: Path) -> float:
+    match = re.search(fr'A=({NUMERIC_PATTERN})', processed_text)
+    if match is None:
+        raise NotImplementedError(f'File {hfi_file} is a crustal age model, but no coefficient (A=) found.')
+    return float(match.group(1))
+
+
+def _get_distance_to_ridge(processed_text: str, hfi_file: Path) -> float:
+    match = re.search(fr'X0=({NUMERIC_PATTERN})', processed_text)
+    if match is None:
+        raise NotImplementedError(f'File {hfi_file} is a crustal age model, but no distance to ridge (X0=) found.')
+    return float(match.group(1))
+
+
+def _read_and_process_hfi(hfi_file: Path) -> str:
+    with open(hfi_file) as f:
+        processed_text = ''
+        save_lines = False
+        for line in f:
+            if line.strip() == 'stop':
+                break
+
+            if save_lines:
+                comments_removed = line.strip().split('%')[0]
+                compressed = comments_removed.replace(' ', '')
+                processed_text += compressed + '\n'
+
+            if line.strip() == 'hflx':
+                save_lines = True
+
+    if not processed_text:
+        raise NotImplementedError(f'File ({hfi_file}) read no text, file format not supported.')
+
+    return processed_text

--- a/test/fehm_objects/fixtures/legacy_jdf.hfi
+++ b/test/fehm_objects/fixtures/legacy_jdf.hfi
@@ -1,0 +1,14 @@
+%HEATFLUX input file (hfi)
+
+% The final function for heatflux must be named "HFLX", but may contain any number of subfunctions.
+% HFLX must also be a function of x, y, and z, even if some or all of these dependencies are null.
+% Use ALL CAPS for all variable or function definitions, to avoid confusion with the main program.
+
+hflx
+A=.367E-6%MegaWatts
+X0=6E4%distance of leftmost edge of model from ridge in m
+SPREADRATE=28.57%spreading rate in mm/yr=km/Ma
+
+AGE=@(x)(1./(SPREADRATE.*1E3)).*(x+X0)%age in Ma
+HFLX=@(x,y,z)A./AGE(x).^(.5)
+stop

--- a/test/fehm_objects/fixtures/legacy_np.hfi
+++ b/test/fehm_objects/fixtures/legacy_np.hfi
@@ -1,0 +1,15 @@
+%HEATFLUX input file (hfi) for strike normal profile of North Pond
+
+% The final function for heatflux must be named "HFLX", but may contain any number of subfunctions.
+% HFLX must also be a function of x, y, and z, even if some or all of these are unused.
+% Use ALL CAPS for all variable or function definitions, to avoid confusion with the main program.
+% Units must be specified in megawatts per m^2.
+
+hflx
+A=5.00E-7%megawatts
+X0=1.44E5%distance of leftmost edge of model from ridge in m
+SPREADRATE=17.00%spreading rate in mm/yr=km/Ma
+
+AGE=@(x)(1./(SPREADRATE.*1E3)).*(-x+X0)%age in Ma negative x means your grid is going toward the spreading center
+HFLX=@(x,y,z)A./AGE(x).^(.5)
+stop

--- a/test/fehm_objects/test_file_readers.py
+++ b/test/fehm_objects/test_file_readers.py
@@ -1,6 +1,7 @@
 from fehm_toolkit.fehm_objects import Element
 from fehm_toolkit.fehm_objects.grid import read_fehm, read_zones
 from fehm_toolkit.fehm_objects.node import Vector
+from fehm_toolkit.config.heat_in import read_legacy_config
 
 
 def test_read_fehm_pyramid(fixture_dir):
@@ -61,4 +62,26 @@ def test_read_area_pyramid(fixture_dir):
         4: (Vector(-30.0, -30.0, -15.0), Vector(30.0, -30.0, -15.0), Vector(0.0, 0.0, 40.0)),
         5: (Vector(30.0, -30.0, -15.0), Vector(30.0, 30.0, -15.0), Vector(0.0, 0.0, 40.0)),
         6: (Vector(30.0, 30.0, -15.0), Vector(-30.0, 30.0, -15.0), Vector(0.0, 0.0, 40.0)),
+    }
+
+
+def test_read_legacy_config_jdf(fixture_dir):
+    config = read_legacy_config(fixture_dir / 'legacy_jdf.hfi')
+    params = config['heatflux']['model_params']
+    assert params == {
+        'crustal_age_sign': 1,
+        'spread_rate_mm_per_year': 28.57,
+        'coefficient_MW': 0.367E-6,
+        'boundary_distance_to_ridge_m': 60000,
+    }
+
+
+def test_read_legacy_config_np(fixture_dir):
+    config = read_legacy_config(fixture_dir / 'legacy_np.hfi')
+    params = config['heatflux']['model_params']
+    assert params == {
+        'crustal_age_sign': -1,
+        'spread_rate_mm_per_year': 17,
+        'coefficient_MW': 0.5E-6,
+        'boundary_distance_to_ridge_m': 144000,
     }


### PR DESCRIPTION
This creates a reader for parsing .hfi files. This parses the Matlab code for crustal age heatflux models and handles that explicitly rather than `eval`ing the code directly (this is a security vulnerability).

I'm only handling the specific format present in the JdF and NP heat input files, but we can extend this to handle other formats fairly easily. @hydrocrust do are you aware of any `.hfi` files for other projects that don't look like the two I've included in this PR?

Note this is called out as a "legacy" config, since I plan to introduce a new config file with a more standardized format called [Yaml](https://yaml.org/). This might be combined in some way with `.rpi` and others, but we're still working out the details.