### PR TITLE
Move hflx writer to separate file

### DIFF
--- a/fehm_toolkit/file_interface/__init__.py
+++ b/fehm_toolkit/file_interface/__init__.py
@@ -1,0 +1,1 @@
+from .compact_node_data import write_compact_node_data

--- a/fehm_toolkit/file_interface/compact_node_data.py
+++ b/fehm_toolkit/file_interface/compact_node_data.py
@@ -1,0 +1,84 @@
+from collections import defaultdict
+from itertools import groupby
+from pathlib import Path
+
+
+def write_compact_node_data(
+    value_by_node: dict[int, float],
+    output_file: Path,
+    header: str = None,
+    footer: str = None,
+):
+    nodes_by_value = _group_nodes_by_formatted_output(value_by_node)
+    ordered_entries = _get_grouped_entries(nodes_by_value)
+    _write_compact_node_file(ordered_entries, output_file, header=header, footer=footer)
+
+
+def _write_compact_node_file(
+    entries: tuple[int, int, str],
+    output_file: Path,
+    header: str = None,
+    footer: str = None,
+):
+    with open(output_file, 'w') as f:
+        if header:
+            f.write(header)
+        for min_node, max_node, value in entries:
+            f.write(_format_compact_entry(min_node, max_node, value))
+        if footer:
+            f.write(footer)
+
+
+def _group_nodes_by_formatted_output(value_by_node: dict[int, float]) -> dict[str, list[int]]:
+    nodes_by_formatted_value = defaultdict(list)
+    for node, value in value_by_node.items():
+        formatted_value = _format_for_output(value)
+        nodes_by_formatted_value[formatted_value].append(node)
+    return nodes_by_formatted_value
+
+
+def _get_grouped_entries(nodes_by_value: dict[str, list[int]]) -> list[tuple[int, int, str]]:
+    entries = []
+    for value, nodes in nodes_by_value.items():
+        for min_node, max_node in _consecutive_groups(sorted(nodes)):
+            entries.append((min_node, max_node, value))
+    return sorted(entries, key=lambda entry: entry[0])  # sort by min_node
+
+
+def _format_compact_entry(min_node: int, max_node: int, value: str) -> str:
+    r""" Format compact node data entry as a string.
+    >>> _format_compact_entry(1, 10, '2.00000E02')
+    '1\t10\t1\t2.00000E02\t0.\n'
+    >>> _format_compact_entry(4, 5, '-3.56738E-04')
+    '4\t5\t1\t-3.56738E-04\t0.\n'
+    """
+    return f'{min_node}\t{max_node}\t1\t{value}\t0.\n'
+
+
+def _consecutive_groups(x: list[int]) -> list[tuple[int]]:
+    """ Iterate over consecutive groups found in list of integers.
+    >>> list(_consecutive_groups([1, 2, 4]))
+    [(1, 2), (4, 4)]
+    >>> list(_consecutive_groups([4, 5, 6, 9, 10, 15, 16]))
+    [(4, 6), (9, 10), (15, 16)]
+    """
+    def _value_minus_index(enum: tuple[int, int]) -> int:
+        index = enum[0]
+        value = enum[1]
+        return index - value
+
+    for k, g in groupby(enumerate(x), key=_value_minus_index):
+        g = list(g)
+        group_start = g[0][1]
+        group_end = g[-1][1]
+        yield group_start, group_end
+
+
+def _format_for_output(value: float) -> str:
+    """ Format float value for output to boundary condition file.
+    >>> _format_for_output(-0.0397631)
+    '-3.97631E-02'
+    >>> _format_for_output(200)
+    '2.00000E+02'
+    """
+    return f"{value:.5E}"

--- a/fehm_toolkit/heat_in.py
+++ b/fehm_toolkit/heat_in.py
@@ -1,12 +1,11 @@
 import argparse
-from collections import defaultdict
-from itertools import groupby
 import logging
 from pathlib import Path
 from typing import Callable, Dict
 
 from .config.heat_in import read_legacy_config
 from .fehm_objects import Grid, Node
+from .file_interface import write_compact_node_data
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +25,7 @@ def generate_input_heatflux_file(
     config = read_legacy_config(config_file)  # TODO(dustin): add support for other config file formats
     grid = Grid.from_files(fehm_file, outside_zone_file=outside_zone_file, area_file=area_file)
     heatflux_by_node = compute_boundary_heatflux(grid, config)
-    write_boundary_heatflux(heatflux_by_node, output_file)
+    write_compact_node_data(heatflux_by_node, output_file, header=HEATFLUX_HEADER, footer=HEATFLUX_FOOTER)
 
 
 def compute_boundary_heatflux(grid: Grid, config: dict[int, float]):
@@ -52,75 +51,6 @@ def _crustal_age_heatflux(node: Node, params: dict) -> float:
     age = 1 / (params['spread_rate_mm_per_year'] * 1E3) * distance_from_ridge
     heatflux_per_area = params['coefficient_MW'] / age ** 0.5
     return -abs(node.outside_area.z * heatflux_per_area)
-
-
-def write_boundary_heatflux(heatflux_by_node: dict[int, float], output_file: Path):
-    nodes_by_heatflux = _group_nodes_by_formatted_heatflux(heatflux_by_node)
-    ordered_heatflux_entries = _get_grouped_heatflux_entries(nodes_by_heatflux)
-    _write_heatflux_file(ordered_heatflux_entries, output_file)
-
-
-def _write_heatflux_file(heatflux_entries: tuple[int, int, str], output_file: Path):
-    with open(output_file, 'w') as f:
-        f.write(HEATFLUX_HEADER)
-        for min_node, max_node, heatflux in heatflux_entries:
-            f.write(_format_heatflux_entry(min_node, max_node, heatflux))
-        f.write(HEATFLUX_FOOTER)
-
-
-def _group_nodes_by_formatted_heatflux(heatflux_by_node: dict[int, float]) -> dict[str, list[int]]:
-    nodes_by_heatflux = defaultdict(list)
-    for node, heatflux in heatflux_by_node.items():
-        formatted_heatflux = _format_heatflux(heatflux)
-        nodes_by_heatflux[formatted_heatflux].append(node)
-    return nodes_by_heatflux
-
-
-def _get_grouped_heatflux_entries(nodes_by_heatflux: dict[str, list[int]]) -> list[tuple[int, int, str]]:
-    heatflux_entries = []
-    for heatflux, nodes in nodes_by_heatflux.items():
-        for min_node, max_node in _consecutive_groups(sorted(nodes)):
-            heatflux_entries.append((min_node, max_node, heatflux))
-    return sorted(heatflux_entries, key=lambda entry: entry[0])  # sort by min_node
-
-
-def _format_heatflux_entry(min_node: int, max_node: int, heatflux: str) -> str:
-    r""" Format heatflux entry as a string.
-    >>> _format_heatflux_entry(1, 10, '2.00000E02')
-    '1\t10\t1\t2.00000E02\t0.\n'
-    >>> _format_heatflux_entry(4, 5, '-3.56738E-04')
-    '4\t5\t1\t-3.56738E-04\t0.\n'
-    """
-    return f'{min_node}\t{max_node}\t1\t{heatflux}\t0.\n'
-
-
-def _consecutive_groups(x: list[int]) -> list[tuple[int]]:
-    """ Iterate over consecutive groups found in list of integers.
-    >>> list(_consecutive_groups([1, 2, 4]))
-    [(1, 2), (4, 4)]
-    >>> list(_consecutive_groups([4, 5, 6, 9, 10, 15, 16]))
-    [(4, 6), (9, 10), (15, 16)]
-    """
-    def _value_minus_index(enum: tuple[int, int]) -> int:
-        index = enum[0]
-        value = enum[1]
-        return index - value
-
-    for k, g in groupby(enumerate(x), key=_value_minus_index):
-        g = list(g)
-        group_start = g[0][1]
-        group_end = g[-1][1]
-        yield group_start, group_end
-
-
-def _format_heatflux(heatflux: float) -> str:
-    """ Format heatflux value for output to boundary condition file.
-    >>> _format_heatflux(-0.0397631)
-    '-3.97631E-02'
-    >>> _format_heatflux(200)
-    '2.00000E+02'
-    """
-    return f"{heatflux:.5E}"
 
 
 if __name__ == '__main__':

--- a/fehm_toolkit/heat_in.py
+++ b/fehm_toolkit/heat_in.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 from pathlib import Path
-from typing import Callable, Dict
+from typing import Callable
 
 from .config.heat_in import read_legacy_config
 from .fehm_objects import Grid, Node
@@ -41,7 +41,7 @@ def compute_boundary_heatflux(grid: Grid, config: dict[int, float]):
     return {node.number: model(node, heatflux_config['model_params']) for node in input_nodes}
 
 
-def get_heatflux_models_by_kind() -> Dict[str, Callable]:
+def get_heatflux_models_by_kind() -> dict[str, Callable]:
     return {'crustal_age': _crustal_age_heatflux}
 
 


### PR DESCRIPTION
Refactor heatflux writer into a separate file. This utility can be used more generally for other compact node formats (perm, cond, rock, etc.), and we can add a reader here in a subsequent PR.