### PR TITLE
Add support for ctr2tcon

### DIFF
--- a/fehm_toolkit/property_models/__init__.py
+++ b/fehm_toolkit/property_models/__init__.py
@@ -1,0 +1,1 @@
+from .ctr2tcon import ctr2tcon

--- a/fehm_toolkit/property_models/ctr2tcon.py
+++ b/fehm_toolkit/property_models/ctr2tcon.py
@@ -20,7 +20,7 @@ def ctr2tcon(depth: float, rock_properties_config: dict, property_kind: str) -> 
     for (lower, upper) in node_ranges_by_depth[nearest_depth]:
         lower, upper = round(lower), round(upper)
         weight_total += upper - lower
-        weighted_tcon_total += sum([tcon_func(d) for d in range(lower, upper, TCON_SPACING_M) if d != 0])
+        weighted_tcon_total += sum([tcon_func(d) for d in range(lower, upper + 1, TCON_SPACING_M) if d != 0])
 
     tcon = weighted_tcon_total / weight_total
     return Vector(x=tcon, y=tcon, z=tcon)

--- a/fehm_toolkit/property_models/ctr2tcon.py
+++ b/fehm_toolkit/property_models/ctr2tcon.py
@@ -1,0 +1,67 @@
+from collections import defaultdict
+import re
+from statistics import mean
+from typing import Callable
+
+from fehm_toolkit.fehm_objects import Vector
+
+TCON_SPACING_M = 1
+
+
+def ctr2tcon(depth: float, rock_properties_config: dict, property_kind: str) -> Vector:
+    params = rock_properties_config[property_kind]['model_params']
+
+    tcon_func = _get_tcon_func(params['ctr_model'])
+    node_ranges_by_depth = _get_node_ranges_by_depth(params['node_depth_columns'])
+
+    nearest_depth = min(node_ranges_by_depth, key=lambda x: abs(x - depth))
+    weight_total = 0
+    weighted_tcon_total = 0
+    for (lower, upper) in node_ranges_by_depth[nearest_depth]:
+        lower, upper = round(lower), round(upper)
+        weight_total += upper - lower
+        weighted_tcon_total += sum([tcon_func(d) for d in range(lower, upper, TCON_SPACING_M) if d != 0])
+
+    tcon = weighted_tcon_total / weight_total
+    return Vector(x=tcon, y=tcon, z=tcon)
+
+
+def _get_node_ranges_by_depth(node_depth_columns: list[list[float]]) -> dict[float, tuple[float]]:
+    node_ranges_by_depth = defaultdict(list)
+    for column in node_depth_columns:
+        if len(column) < 2:
+            raise ValueError(f'Node column is invalid (not enough values): {column}')
+
+        if len(column) == 2:
+            node_ranges_by_depth[column[0]].append(tuple(column))
+            continue
+
+        first_node_range = (column[0], mean(column[0:2]))
+        node_ranges_by_depth[column[0]].append(first_node_range)
+
+        last_node_range = (mean(column[-3:-1]), column[-1])
+        node_ranges_by_depth[column[-2]].append(last_node_range)
+
+        for previous_depth, node_depth, next_depth in zip(column[0:-3], column[1:-2], column[2:-1]):
+            node_range = (mean([previous_depth, node_depth]), mean([node_depth, next_depth]))
+            node_ranges_by_depth[node_depth].append(node_range)
+
+    return node_ranges_by_depth
+
+
+def _get_tcon_func(ctr_model_config: dict) -> Callable:
+    if ctr_model_config['model_kind'] not in ('polynomial'):
+        raise NotImplementedError(f"CTR model kind not supported: {ctr_model_config['model_kind']}")
+
+    resistance_terms = []
+    for key, coefficient in ctr_model_config['model_params'].items():
+        match = re.search(r'x\^(-{0,1}\d+)', key)
+        if not match:
+            raise KeyError(f"Invalid key in polynomial config: {ctr_model_config['model_params']}")
+        resistance_terms.append((coefficient, float(match.group(1))))
+
+    def tcon(depth: float):
+        resistance_derivitive_terms = [coeff * power * depth ** (power - 1) for coeff, power in resistance_terms]
+        return 1 / sum(resistance_derivitive_terms)
+
+    return tcon

--- a/fehm_toolkit/rock_properties.py
+++ b/fehm_toolkit/rock_properties.py
@@ -9,6 +9,7 @@ import numpy as np
 from .config import read_legacy_rpi_config
 from .fehm_objects import Grid, Node, Vector
 from .file_interface import write_compact_node_data
+from . import property_models
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +85,7 @@ def get_rock_property_model(model_kind) -> dict[str, Callable]:
     models_by_kind = {
         'constant': _constant,
         'porosity_weighted_conductivity': _porosity_weighted_conductivity,
+        'ctr2tcon': property_models.ctr2tcon,
         'sediment_porosity_depth_power_law': _sediment_porosity_depth_power_law,
         'min_sediment_porosity_exponential': _min_sediment_porosity_exponential,
         'void_ratio_power_law': _void_ratio_power_law,


### PR DESCRIPTION
I don't think this should actually be supported by `rock_properties` itself; the conversion from CTR to conductivity is substantial enough to warrant its own tool and output files, but I'm including it like this for now in the name of backwards compatibility.

The Matlab version uses an iterative optimisation function to solve this problem, but that isn't strictly necessary for polynomial CTR profiles (which is all we have) - so I've opted to remove the optimiser and do a simple derivative instead. This simplifies the code, but does yield slightly different (1-2%) results. I consider this acceptable, and will inspect all of the JdF fixture files to ensure there are no deviations beyond this.