### PR TITLE
Create end-to-end tests for rock property fixtures

### DIFF
--- a/test/end_to_end/test_written_files.py
+++ b/test/end_to_end/test_written_files.py
@@ -47,11 +47,15 @@ def test_heat_in_against_fixture(tmpdir, matlab_fixture_dir, model_name, model_r
         # TODO(dustin): replace these with small custom grids
         ('np2d_cond', 'cond'),
         ('np2d_p11', 'run'),
+        ('jdf3d_p12d_g981', 'p12d_g981'),
+
+        # Fails on ppor file, needs investigation of Matlab code
         # ('np3d_cond', 'run'),
-        ('jdf2d_p12', 'p12'),
-        # ('jdf3d_p12d_g981', 'p12d_g981'),
-        # ('jdf3d_p12', 'p12'),
-        # ('jdf3d_conduit_p12', 'p12'),
+        # ('jdf2d_p12', 'p12'),
+
+        # Fails to read grid, needs material zone file (can relax all zones covered req or include material zone)
+        # ('jdf3d_p12', 'p12'),  # check ppor and cond
+        # ('jdf3d_conduit_p12', 'p12'),  # check ppor and cond
     )
 )
 def test_rock_properties_against_fixture(tmpdir, matlab_fixture_dir, model_name, model_root):
@@ -69,7 +73,7 @@ def test_rock_properties_against_fixture(tmpdir, matlab_fixture_dir, model_name,
     )
 
     for output_extension in ('cond', 'perm', 'ppor', 'rock'):
-        if model_name in ('jdf2d_p12',) and output_extension == 'cond':
+        if model_name in ('jdf2d_p12', 'jdf3d_p12d_g981') and output_extension == 'cond':
             logger.info('Skipping file check (%s, %s), small variation expected.', model_name, output_extension)
             continue
 

--- a/test/end_to_end/test_written_files.py
+++ b/test/end_to_end/test_written_files.py
@@ -49,13 +49,11 @@ def test_heat_in_against_fixture(tmpdir, matlab_fixture_dir, model_name, model_r
         ('np2d_p11', 'run'),
         ('jdf3d_p12d_g981', 'p12d_g981'),
 
-        # Fails on ppor file, needs investigation of Matlab code
+        # Fails on ppor file due to bugs in fixture version which have been addressed
+        # jdf runs also fail on cond due to small expected variation in ctr2tcon calculation
         # ('np3d_cond', 'run'),
         # ('jdf2d_p12', 'p12'),
-
-        # Fails to read grid, needs material zone file (can relax all zones covered req or include material zone)
-        # ('jdf3d_p12', 'p12'),  # check ppor and cond
-        # ('jdf3d_conduit_p12', 'p12'),  # check ppor and cond
+        # ('jdf3d_p12', 'p12'),
     )
 )
 def test_rock_properties_against_fixture(tmpdir, matlab_fixture_dir, model_name, model_root):

--- a/test/end_to_end/test_written_files.py
+++ b/test/end_to_end/test_written_files.py
@@ -1,6 +1,12 @@
+import logging
+
 import pytest
 
+
 from fehm_toolkit.heat_in import generate_input_heatflux_file
+from fehm_toolkit.rock_properties import generate_rock_properties_files
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize(
@@ -16,7 +22,7 @@ from fehm_toolkit.heat_in import generate_input_heatflux_file
         ('np3d_cond', 'run'),
     )
 )
-def test_against_jdf2d_fixture(tmpdir, matlab_fixture_dir, model_name, model_root):
+def test_heat_in_against_fixture(tmpdir, matlab_fixture_dir, model_name, model_root):
     model_dir = matlab_fixture_dir / model_name
     generate_input_heatflux_file(
         config_file=model_dir / f'{model_root}.hfi',
@@ -33,3 +39,46 @@ def test_against_jdf2d_fixture(tmpdir, matlab_fixture_dir, model_name, model_roo
         actual = output_file.read()
 
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    'model_name, model_root',
+    (
+        # TODO(dustin): replace these with small custom grids
+        ('np2d_cond', 'cond'),
+        ('np2d_p11', 'run'),
+        # ('np3d_cond', 'run'),
+        ('jdf2d_p12', 'p12'),
+        # ('jdf3d_p12d_g981', 'p12d_g981'),
+        # ('jdf3d_p12', 'p12'),
+        # ('jdf3d_conduit_p12', 'p12'),
+    )
+)
+def test_rock_properties_against_fixture(tmpdir, matlab_fixture_dir, model_name, model_root):
+    logger.info(f'Generating rock properties files ({model_name}).')
+    model_dir = matlab_fixture_dir / model_name
+    generate_rock_properties_files(
+        config_file=model_dir / f'{model_root}.rpi',
+        fehm_file=model_dir / f'{model_root}.fehm',
+        outside_zone_file=model_dir / f'{model_root}_outside.zone',
+        material_zone_file=model_dir / f'{model_root}_material.zone',
+        cond_output_file=tmpdir / 'output.cond',
+        perm_output_file=tmpdir / 'output.perm',
+        ppor_output_file=tmpdir / 'output.ppor',
+        rock_output_file=tmpdir / 'output.rock',
+    )
+
+    for output_extension in ('cond', 'perm', 'ppor', 'rock'):
+        if model_name in ('jdf2d_p12',) and output_extension == 'cond':
+            logger.info('Skipping file check (%s, %s), small variation expected.', model_name, output_extension)
+            continue
+
+        logger.info(f'Comparing output for {output_extension} file.')
+        with open(model_dir / f'{model_root}.{output_extension}') as fixture_file:
+            expected = fixture_file.read()
+
+        with open(tmpdir / f'output.{output_extension}') as output_file:
+            actual = output_file.read()
+
+        equal = actual == expected
+        assert equal


### PR DESCRIPTION
This creates tests against fixtures where possible, which is only a few model runs ([see Trello card](https://trello.com/c/iAs2Qf6k)). Others that can't be run due to expected variations from the fixtures are mentioned but commented out, along with descriptions of why they're omitted.