### PR TITLE
Separate readers

### DIFF
--- a/fehm_toolkit/fehm_objects/__init__.py
+++ b/fehm_toolkit/fehm_objects/__init__.py
@@ -1,3 +1,4 @@
 from .element import Element
 from .grid import Grid
-from .node import Node, Vector
+from .node import Node
+from .vector import Vector

--- a/fehm_toolkit/fehm_objects/grid.py
+++ b/fehm_toolkit/fehm_objects/grid.py
@@ -5,9 +5,10 @@ from typing import Optional, Iterable, Union
 import numpy as np
 from scipy import interpolate
 
+from ..file_interface import read_fehm, read_zones
 from .element import Element
-from .file_interface import read_fehm, read_zones
-from .node import Node, Vector
+from .node import Node
+from .vector import Vector
 
 
 logger = logging.getLogger(__name__)

--- a/fehm_toolkit/fehm_objects/grid.py
+++ b/fehm_toolkit/fehm_objects/grid.py
@@ -1,11 +1,12 @@
 import logging
 from pathlib import Path
-from typing import Optional, Iterable, TextIO, Union
+from typing import Optional, Iterable, Union
 
 import numpy as np
 from scipy import interpolate
 
 from .element import Element
+from .file_interface import read_fehm, read_zones
 from .node import Node, Vector
 
 
@@ -178,173 +179,6 @@ def _construct_nodes_lookup(
         )
         for number, coordinates in coordinates_by_number.items()
     }
-
-
-def read_fehm(fehm_file: Path, read_elements: Optional[bool] = True) -> tuple[dict, dict]:
-    """Read FEHM-formatted files (.fehm)
-
-    Read coordinates and elements and return as dictionaries keyed by number.
-    """
-
-    coordinates_by_number = None
-    elements_by_number = None
-
-    with open(fehm_file) as f:
-        while True:
-            block_name = next(f).strip()
-
-            if block_name == 'coor':
-                coordinates_by_number = _read_coor(f)
-            elif block_name == 'elem':
-                elements_by_number = _read_elem(f, should_read=read_elements)
-            elif block_name == 'stop':
-                break
-            else:
-                raise NotImplementedError(f'No parser for block type "{block_name}"')
-            next(f)  # throw away extra line after block
-
-    if not coordinates_by_number:
-        raise ValueError(f'Invalid fehm_file ({fehm_file}), no coordinate data found')
-    if read_elements and not elements_by_number:
-        raise ValueError(f'Invalid fehm_file ({fehm_file}), no element data found')
-
-    return coordinates_by_number, elements_by_number
-
-
-def _read_coor(open_file: TextIO) -> dict[int, Vector]:
-    n_nodes = int(next(open_file))
-
-    coordinates_by_number = {}
-    for i in range(n_nodes):
-        number, x, y, z = next(open_file).strip().split()
-        coordinates_by_number[int(number)] = Vector(float(x), float(y), float(z))
-
-    return coordinates_by_number
-
-
-def _read_elem(open_file: TextIO, should_read: Optional[bool] = True) -> dict[int, Node]:
-    n_elements = int(next(open_file).strip().split()[1])
-
-    elements_by_number = {}
-    for i in range(n_elements):
-        line = next(open_file)
-        if not should_read:
-            continue
-
-        element = Element.from_fehm_line(line)
-        elements_by_number[element.number] = element
-    return elements_by_number
-
-
-def read_zones(zone_file: Path) -> tuple[dict, dict]:
-    """Read zone-formatted files (_outside.zone, _material.zone, .area)
-
-    Read zone-based values (node numbers, areas), and return these as a dictionary keyed by zone number. Also construct
-    a mapping dictionary between the zone name and zone number.
-    """
-
-    zone_number_by_name = {}
-    node_values_by_zone_number = {}
-
-    with open(zone_file) as f:
-        file_header = next(f).strip()
-        if file_header != 'zone':
-            raise ValueError('Invalid zone file, must start with "zone" header')
-
-        while True:
-            zone_header = next(f).strip()
-            if _is_end_of_zone_file(zone_header, f):
-                break
-
-            zone_number, zone_name = _parse_zone_header(zone_header)
-            node_values = _read_zone(f)
-
-            node_values_by_zone_number[zone_number] = node_values
-            if zone_name:
-                zone_number_by_name[zone_name] = zone_number
-
-    return node_values_by_zone_number, zone_number_by_name
-
-
-def _read_zone(open_file: TextIO) -> tuple[int]:
-    nnum_header = next(open_file).strip()
-    if nnum_header != 'nnum':
-        raise ValueError(f'Invalid zone file, expected "nnum" instead of "{nnum_header}"')
-
-    n_nodes = int(next(open_file).strip())
-    node_values = []
-    while len(node_values) < n_nodes:
-        raw_values_for_line = next(open_file).strip().split()
-        if not node_values:
-            is_vector_format = _is_vector_formatted(raw_values_for_line, n_nodes)
-
-        values_for_line = _parse_zone_values_line(raw_values_for_line, is_vector_format=is_vector_format)
-        node_values.extend(values_for_line)
-
-    return tuple(node_values)
-
-
-def _parse_zone_header(header: str) -> tuple[int, Optional[str]]:
-    """ Split up a zone header string into the number and name (if present)
-    >>> _parse_zone_header('00001 top')
-    (1, 'top')
-    >>> _parse_zone_header('00003')
-    (3, None)
-    >>> _parse_zone_header('4 front_s')
-    (4, 'front_s')
-    """
-    parsed = header.strip().split()
-    if len(parsed) == 1:
-        return int(parsed[0]), None
-
-    return int(parsed[0]), parsed[1]
-
-
-def _is_end_of_zone_file(header: str, open_file: TextIO) -> bool:
-    if not header:
-        if next(open_file).strip() != 'stop':
-            raise ValueError('Invalid zone file, unexpected blank line encountered')
-        return True
-    return False
-
-
-def _parse_zone_values_line(raw_line_values: list[str], is_vector_format: bool) -> list:
-    """ Convert zone values into a list of scalar or vector values
-    >>> _parse_zone_values_line(['1', '2', '3', '4', '5', '6', '7', '8', '9', '10'], False)
-    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-    >>> _parse_zone_values_line(['1', '2', '3', '4', '5', '6'], False)
-    [1, 2, 3, 4, 5, 6]
-    >>> _parse_zone_values_line(['1', '2', '3', '4', '5', '6'], True)
-    [Vector(x=1.0, y=2.0, z=3.0), Vector(x=4.0, y=5.0, z=6.0)]
-    >>> _parse_zone_values_line(['1', '2', '3', '4', '5', '6', '7'], True)
-    [Vector(x=1.0, y=2.0, z=3.0), Vector(x=4.0, y=5.0, z=6.0)]
-    >>> _parse_zone_values_line(['1.0', '1.0', '4.5'], True)
-    [Vector(x=1.0, y=1.0, z=4.5)]
-    """
-    if is_vector_format:
-        first = Vector(*(float(v) for v in raw_line_values[:3]))
-        second = Vector(*(float(v) for v in raw_line_values[3:6])) if raw_line_values[3:6] else None
-        if not second:
-            return [first]
-        return [first, second]
-
-    return [int(v) for v in raw_line_values]
-
-
-def _is_vector_formatted(zone_line_values: list[str], n_nodes: int) -> bool:
-    """ Check if line is vector formatted (contains 6 values)
-    >>> _is_vector_formatted(['10.0', '10.0', '0.0', '0.0', '20.0', '20.0'], 10)
-    True
-    >>> _is_vector_formatted([1, 2, 3], 1)
-    True
-    >>> _is_vector_formatted(['1.0', '2.0', '3.0'], 2)
-    False
-    >>> _is_vector_formatted([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 10)
-    False
-    """
-    if n_nodes == 1:
-        return len(zone_line_values) == 3
-    return len(zone_line_values) == 6  # Lagrit writes two 3-vectors per line instead of the usual 10 scalars
 
 
 def _get_area_by_node_number(

--- a/fehm_toolkit/fehm_objects/node.py
+++ b/fehm_toolkit/fehm_objects/node.py
@@ -1,12 +1,14 @@
 from dataclasses import dataclass
 
+from .vector import Vector
+
 
 @dataclass
 class Node:
     """Class for tracking individual node properties."""
     number: int
-    coordinates: 'Vector'
-    outside_area: 'Vector' = None
+    coordinates: Vector
+    outside_area: Vector = None
     depth: float = None
 
     @property
@@ -20,18 +22,3 @@ class Node:
     @property
     def z(self):
         return self.coordinates.z
-
-
-@dataclass
-class Vector:
-    """Class for tracking vector values (e.g. vornoi areas)."""
-    x: float
-    y: float
-    z: float
-
-    @property
-    def value(self) -> tuple[float]:
-        return (self.x, self.y, self.z)
-
-    def __format__(self, fmt) -> str:
-        return f'{self.x:{fmt}}\t{self.y:{fmt}}\t{self.z:{fmt}}'

--- a/fehm_toolkit/fehm_objects/vector.py
+++ b/fehm_toolkit/fehm_objects/vector.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Vector:
+    """Class for tracking vector values (e.g. vornoi areas)."""
+    x: float
+    y: float
+    z: float
+
+    @property
+    def value(self) -> tuple[float]:
+        return (self.x, self.y, self.z)
+
+    def __format__(self, fmt) -> str:
+        return f'{self.x:{fmt}}\t{self.y:{fmt}}\t{self.z:{fmt}}'

--- a/fehm_toolkit/file_interface/__init__.py
+++ b/fehm_toolkit/file_interface/__init__.py
@@ -1,1 +1,3 @@
 from .compact_node_data import write_compact_node_data
+from .fehm import read_fehm
+from .zone import read_zones

--- a/fehm_toolkit/file_interface/compact_node_data.py
+++ b/fehm_toolkit/file_interface/compact_node_data.py
@@ -3,7 +3,7 @@ from itertools import groupby
 from pathlib import Path
 from typing import Iterable, Union
 
-from fehm_toolkit.fehm_objects import Vector
+from ..fehm_objects.vector import Vector
 
 
 def read_compact_node_data(compact_node_data_file: Path) -> dict[int, float]:

--- a/fehm_toolkit/file_interface/fehm.py
+++ b/fehm_toolkit/file_interface/fehm.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+from typing import Optional, TextIO
+
+from fehm_toolkit.fehm_objects import Element, Node, Vector
+
+
+def read_fehm(fehm_file: Path, read_elements: Optional[bool] = True) -> tuple[dict, dict]:
+    """Read FEHM-formatted files (.fehm)
+
+    Read coordinates and elements and return as dictionaries keyed by number.
+    """
+
+    coordinates_by_number = None
+    elements_by_number = None
+
+    with open(fehm_file) as f:
+        while True:
+            block_name = next(f).strip()
+
+            if block_name == 'coor':
+                coordinates_by_number = _read_coor(f)
+            elif block_name == 'elem':
+                elements_by_number = _read_elem(f, should_read=read_elements)
+            elif block_name == 'stop':
+                break
+            else:
+                raise NotImplementedError(f'No parser for block type "{block_name}"')
+            next(f)  # throw away extra line after block
+
+    if not coordinates_by_number:
+        raise ValueError(f'Invalid fehm_file ({fehm_file}), no coordinate data found')
+    if read_elements and not elements_by_number:
+        raise ValueError(f'Invalid fehm_file ({fehm_file}), no element data found')
+
+    return coordinates_by_number, elements_by_number
+
+
+def _read_coor(open_file: TextIO) -> dict[int, Vector]:
+    n_nodes = int(next(open_file))
+
+    coordinates_by_number = {}
+    for i in range(n_nodes):
+        number, x, y, z = next(open_file).strip().split()
+        coordinates_by_number[int(number)] = Vector(float(x), float(y), float(z))
+
+    return coordinates_by_number
+
+
+def _read_elem(open_file: TextIO, should_read: Optional[bool] = True) -> dict[int, Node]:
+    n_elements = int(next(open_file).strip().split()[1])
+
+    elements_by_number = {}
+    for i in range(n_elements):
+        line = next(open_file)
+        if not should_read:
+            continue
+
+        element = Element.from_fehm_line(line)
+        elements_by_number[element.number] = element
+    return elements_by_number

--- a/fehm_toolkit/file_interface/fehm.py
+++ b/fehm_toolkit/file_interface/fehm.py
@@ -1,7 +1,9 @@
 from pathlib import Path
 from typing import Optional, TextIO
 
-from fehm_toolkit.fehm_objects import Element, Node, Vector
+from ..fehm_objects.element import Element
+from ..fehm_objects.node import Node
+from ..fehm_objects.vector import Vector
 
 
 def read_fehm(fehm_file: Path, read_elements: Optional[bool] = True) -> tuple[dict, dict]:

--- a/fehm_toolkit/file_interface/zone.py
+++ b/fehm_toolkit/file_interface/zone.py
@@ -1,0 +1,115 @@
+from pathlib import Path
+from typing import Optional, TextIO
+
+from fehm_toolkit.fehm_objects import Vector
+
+
+def read_zones(zone_file: Path) -> tuple[dict, dict]:
+    """Read zone-formatted files (_outside.zone, _material.zone, .area)
+
+    Read zone-based values (node numbers, areas), and return these as a dictionary keyed by zone number. Also construct
+    a mapping dictionary between the zone name and zone number.
+    """
+
+    zone_number_by_name = {}
+    node_values_by_zone_number = {}
+
+    with open(zone_file) as f:
+        file_header = next(f).strip()
+        if file_header != 'zone':
+            raise ValueError('Invalid zone file, must start with "zone" header')
+
+        while True:
+            zone_header = next(f).strip()
+            if _is_end_of_zone_file(zone_header, f):
+                break
+
+            zone_number, zone_name = _parse_zone_header(zone_header)
+            node_values = _read_zone(f)
+
+            node_values_by_zone_number[zone_number] = node_values
+            if zone_name:
+                zone_number_by_name[zone_name] = zone_number
+
+    return node_values_by_zone_number, zone_number_by_name
+
+
+def _read_zone(open_file: TextIO) -> tuple[int]:
+    nnum_header = next(open_file).strip()
+    if nnum_header != 'nnum':
+        raise ValueError(f'Invalid zone file, expected "nnum" instead of "{nnum_header}"')
+
+    n_nodes = int(next(open_file).strip())
+    node_values = []
+    while len(node_values) < n_nodes:
+        raw_values_for_line = next(open_file).strip().split()
+        if not node_values:
+            is_vector_format = _is_vector_formatted(raw_values_for_line, n_nodes)
+
+        values_for_line = _parse_zone_values_line(raw_values_for_line, is_vector_format=is_vector_format)
+        node_values.extend(values_for_line)
+
+    return tuple(node_values)
+
+
+def _parse_zone_header(header: str) -> tuple[int, Optional[str]]:
+    """ Split up a zone header string into the number and name (if present)
+    >>> _parse_zone_header('00001 top')
+    (1, 'top')
+    >>> _parse_zone_header('00003')
+    (3, None)
+    >>> _parse_zone_header('4 front_s')
+    (4, 'front_s')
+    """
+    parsed = header.strip().split()
+    if len(parsed) == 1:
+        return int(parsed[0]), None
+
+    return int(parsed[0]), parsed[1]
+
+
+def _is_end_of_zone_file(header: str, open_file: TextIO) -> bool:
+    if not header:
+        if next(open_file).strip() != 'stop':
+            raise ValueError('Invalid zone file, unexpected blank line encountered')
+        return True
+    return False
+
+
+def _parse_zone_values_line(raw_line_values: list[str], is_vector_format: bool) -> list:
+    """ Convert zone values into a list of scalar or vector values
+    >>> _parse_zone_values_line(['1', '2', '3', '4', '5', '6', '7', '8', '9', '10'], False)
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    >>> _parse_zone_values_line(['1', '2', '3', '4', '5', '6'], False)
+    [1, 2, 3, 4, 5, 6]
+    >>> _parse_zone_values_line(['1', '2', '3', '4', '5', '6'], True)
+    [Vector(x=1.0, y=2.0, z=3.0), Vector(x=4.0, y=5.0, z=6.0)]
+    >>> _parse_zone_values_line(['1', '2', '3', '4', '5', '6', '7'], True)
+    [Vector(x=1.0, y=2.0, z=3.0), Vector(x=4.0, y=5.0, z=6.0)]
+    >>> _parse_zone_values_line(['1.0', '1.0', '4.5'], True)
+    [Vector(x=1.0, y=1.0, z=4.5)]
+    """
+    if is_vector_format:
+        first = Vector(*(float(v) for v in raw_line_values[:3]))
+        second = Vector(*(float(v) for v in raw_line_values[3:6])) if raw_line_values[3:6] else None
+        if not second:
+            return [first]
+        return [first, second]
+
+    return [int(v) for v in raw_line_values]
+
+
+def _is_vector_formatted(zone_line_values: list[str], n_nodes: int) -> bool:
+    """ Check if line is vector formatted (contains 6 values)
+    >>> _is_vector_formatted(['10.0', '10.0', '0.0', '0.0', '20.0', '20.0'], 10)
+    True
+    >>> _is_vector_formatted([1, 2, 3], 1)
+    True
+    >>> _is_vector_formatted(['1.0', '2.0', '3.0'], 2)
+    False
+    >>> _is_vector_formatted([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 10)
+    False
+    """
+    if n_nodes == 1:
+        return len(zone_line_values) == 3
+    return len(zone_line_values) == 6  # Lagrit writes two 3-vectors per line instead of the usual 10 scalars

--- a/fehm_toolkit/file_interface/zone.py
+++ b/fehm_toolkit/file_interface/zone.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Optional, TextIO
 
-from fehm_toolkit.fehm_objects import Vector
+from ..fehm_objects.vector import Vector
 
 
 def read_zones(zone_file: Path) -> tuple[dict, dict]:


### PR DESCRIPTION
This splits out the .zone and .fehm file reader code out into their own modules in the `file_interface` package, and modifies the `__init__.py` so they can be easily imported.

I'm doing this in preparation for using the zone reader for the `append_zone` utility. When the only thing using the zone reader was the grid, it was alright to keep it in the same file, but now that I need it in two places it will be cleaner to give it its own separate home.

@kristindickerson I think this is a good example that highlights some of the packaging/imports stuff we discussed.