### PR TITLE
Separate property models

### DIFF
--- a/fehm_toolkit/config/rpi_reader.py
+++ b/fehm_toolkit/config/rpi_reader.py
@@ -129,12 +129,12 @@ def _get_models() -> tuple[tuple[str, str, Callable]]:
             'parser': _parse_params__assigned_constant,
         },
         {
-            'model_kind': 'min_sediment_porosity_exponential',
+            'model_kind': 'depth_exponential_with_maximum',
             'signature': r'FUN=@\(depth\)min\(PORA\.\*depth\.\^\(PORB\),PORA\.\*50\.\^\(PORB\)\)(?:;|\n)',
             'parser': _parse_params__sediment_porosity,
         },
         {
-            'model_kind': 'sediment_porosity_depth_power_law',
+            'model_kind': 'depth_power_law',
             'signature': r'FUN=@\(depth\)PORA\.\*exp\(PORB\.\*depth\);',
             'parser': _parse_params__sediment_porosity,
         },
@@ -144,9 +144,9 @@ def _get_models() -> tuple[tuple[str, str, Callable]]:
             'parser': _parse_params__jdf_ctr2tcon,
         },
         {
-            'model_kind': 'porosity_weighted_conductivity',
+            'model_kind': 'porosity_weighted',
             'signature': r'FUN=@\(depth,porosity\)\(KW\.\^porosity\)\.\*\(\w+\.\^\(1-porosity\)\)(?:;|\n)',
-            'parser': _parse_params__porosity_weighted_conductivity,
+            'parser': _parse_params__porosity_weighted,
         },
         {
             'model_kind': 'void_ratio_power_law',
@@ -154,9 +154,9 @@ def _get_models() -> tuple[tuple[str, str, Callable]]:
             'parser': _parse_params__void_ratio_power_law,
         },
         {
-            'model_kind': 'overburden_compressibility',
+            'model_kind': 'overburden',
             'signature': r'FUN=@\(depth,porosity\)0\.435\.\*A\.\*\(1-porosity\)\./OB\(depth\)(?:;|\n)',
-            'parser': _parse_params__overburden_compressibility,
+            'parser': _parse_params__overburden,
         },
     )
 
@@ -208,7 +208,7 @@ def _parse_params__jdf_ctr2tcon(block: str) -> dict:
     }
 
 
-def _parse_params__porosity_weighted_conductivity(block: str) -> dict:
+def _parse_params__porosity_weighted(block: str) -> dict:
     match_var = re.search(r'FUN=@\(depth,porosity\)\(KW\.\^porosity\)\.\*\((\w+)\.\^\(1-porosity\)\)(?:;|\n)', block)
     grain_conductivity_variable = match_var.group(1)
 
@@ -227,7 +227,7 @@ def _parse_params__void_ratio_power_law(block: str) -> dict:
     return {'A': float(match_a.group(1)), 'B': float(match_b.group(1))}
 
 
-def _parse_params__overburden_compressibility(block: str) -> dict:
+def _parse_params__overburden(block: str) -> dict:
     match_a = re.search(rf'A=({NUMERIC_PATTERN})(?:;|\n)', block)
     match_grav = re.search(rf'GRAV=({NUMERIC_PATTERN})(?:;|\n)', block)
     match_rhow = re.search(rf'RHOW=({NUMERIC_PATTERN})(?:;|\n)', block)

--- a/fehm_toolkit/property_models/__init__.py
+++ b/fehm_toolkit/property_models/__init__.py
@@ -1,1 +1,1 @@
-from .ctr2tcon import ctr2tcon
+from .models import get_rock_property_model

--- a/fehm_toolkit/property_models/compressibility.py
+++ b/fehm_toolkit/property_models/compressibility.py
@@ -1,0 +1,32 @@
+import math
+
+import numpy as np
+
+from .generic import get_generic_model
+from .porosity import get_porosity_model
+
+
+def get_compressibility_models_by_kind() -> dict:
+    return {
+        'overburden': _overburden,
+    }
+
+
+def _overburden(depth: float, rock_properties_config: dict, property_kind: str) -> float:
+    params = rock_properties_config[property_kind]['model_params']
+    porosity_model = get_porosity_model(rock_properties_config['porosity']['model_kind'])
+    grain_density_model = get_generic_model(  # no grain_density-specific models exist at time of writing, using generic
+        model_kind=rock_properties_config['grain_density']['model_kind']
+    )
+
+    depth_column_1m_spacing = list(range(math.floor(depth) + 1)) if depth else [0]
+    porosity_column = np.array([
+        porosity_model(d, rock_properties_config, 'porosity') for d in depth_column_1m_spacing
+    ])
+    grain_density_column = np.array([
+        grain_density_model(depth, rock_properties_config, 'grain_density') for d in depth_column_1m_spacing
+    ])
+    rho_wet_bulk_column = (1 - porosity_column) * grain_density_column + porosity_column * params['rhow']
+    overburden = max(params['grav'] * sum(rho_wet_bulk_column - params['rhow']), params['min_overburden'])
+    porosity = porosity_model(depth, rock_properties_config, 'porosity')
+    return 0.435 * params['a'] * (1 - porosity) / overburden

--- a/fehm_toolkit/property_models/generic.py
+++ b/fehm_toolkit/property_models/generic.py
@@ -1,0 +1,23 @@
+from typing import Callable, Union
+
+from ..fehm_objects import Vector
+
+
+def get_generic_model(model_kind) -> Callable:
+    return get_generic_models_by_kind()[model_kind]
+
+
+def get_generic_models_by_kind() -> dict:
+    return {
+        'constant': _constant,
+    }
+
+
+def _constant(depth: float, rock_properties_config: dict, property_kind: str) -> Union[float, Vector]:
+    params = rock_properties_config[property_kind]['model_params']
+    constant = params['constant']
+
+    if property_kind in ('conductivity', 'permeability'):
+        return Vector(x=constant, y=constant, z=constant)
+
+    return constant

--- a/fehm_toolkit/property_models/models.py
+++ b/fehm_toolkit/property_models/models.py
@@ -8,7 +8,6 @@ from .porosity import get_porosity_models_by_kind
 
 
 def get_rock_property_model(property_kind, model_kind) -> dict[str, Callable]:
-
     property_model_lookup = _get_model_lookup_by_property_kind()[property_kind]
     generic_model_lookup = get_generic_models_by_kind()
 

--- a/fehm_toolkit/property_models/models.py
+++ b/fehm_toolkit/property_models/models.py
@@ -1,0 +1,29 @@
+from typing import Callable
+
+from .compressibility import get_compressibility_models_by_kind
+from .conductivity import get_conductivity_models_by_kind
+from .generic import get_generic_models_by_kind
+from .permeability import get_permeability_models_by_kind
+from .porosity import get_porosity_models_by_kind
+
+
+def get_rock_property_model(property_kind, model_kind) -> dict[str, Callable]:
+
+    property_model_lookup = _get_model_lookup_by_property_kind()[property_kind]
+    generic_model_lookup = get_generic_models_by_kind()
+
+    try:
+        return property_model_lookup[model_kind]
+    except KeyError:
+        return generic_model_lookup[model_kind]
+
+
+def _get_model_lookup_by_property_kind() -> dict:
+    return {
+        'grain_density': {},
+        'specific_heat': {},
+        'porosity': get_porosity_models_by_kind(),
+        'conductivity': get_conductivity_models_by_kind(),
+        'permeability': get_permeability_models_by_kind(),
+        'compressibility': get_compressibility_models_by_kind(),
+    }

--- a/fehm_toolkit/property_models/permeability.py
+++ b/fehm_toolkit/property_models/permeability.py
@@ -1,0 +1,21 @@
+import math
+
+from ..fehm_objects import Vector
+from .porosity import get_porosity_model
+
+
+def get_permeability_models_by_kind() -> dict:
+    return {
+        'void_ratio_power_law': _void_ratio_power_law,
+    }
+
+
+def _void_ratio_power_law(depth: float, rock_properties_config: dict, property_kind: str) -> Vector:
+    params = rock_properties_config[property_kind]['model_params']
+
+    porosity_model = get_porosity_model(rock_properties_config['porosity']['model_kind'])
+    porosity = porosity_model(depth, rock_properties_config, 'porosity')
+
+    void_ratio = porosity / (1 - porosity)
+    permeability = params['A'] * math.exp(params['B'] * void_ratio)
+    return Vector(x=permeability, y=permeability, z=permeability)

--- a/fehm_toolkit/property_models/porosity.py
+++ b/fehm_toolkit/property_models/porosity.py
@@ -1,0 +1,37 @@
+import math
+from typing import Callable
+
+from .generic import get_generic_models_by_kind
+
+
+def get_porosity_model(model_kind: str) -> Callable:
+    porosity_models_by_kind = get_porosity_models_by_kind()
+    generic_models_by_kind = get_generic_models_by_kind()
+    try:
+        return porosity_models_by_kind[model_kind]
+    except KeyError:
+        return generic_models_by_kind[model_kind]
+
+
+def get_porosity_models_by_kind() -> dict:
+    return {
+        'depth_power_law': _depth_power_law,
+        'depth_exponential_with_maximum': _depth_exponential_with_maximum,
+    }
+
+
+def _depth_power_law(depth: float, rock_properties_config: dict, property_kind: str) -> float:
+    params = rock_properties_config[property_kind]['model_params']
+    porosity_a, porosity_b = params['porosity_a'], params['porosity_b']
+    return porosity_a * math.exp(porosity_b * depth)
+
+
+def _depth_exponential_with_maximum(depth: float, rock_properties_config: dict, property_kind: str) -> float:
+    params = rock_properties_config[property_kind]['model_params']
+    porosity_a, porosity_b = params['porosity_a'], params['porosity_b']
+
+    max_porosity = porosity_a * 50 ** porosity_b
+    if depth == 0:
+        return max_porosity
+
+    return min(porosity_a * depth ** porosity_b, max_porosity)

--- a/test/config/test_legacy_readers.py
+++ b/test/config/test_legacy_readers.py
@@ -31,7 +31,7 @@ def test_read_legacy_rpi_config_jdf(fixture_dir):
             1: {
                 "porosity":
                 {
-                    "model_kind": "min_sediment_porosity_exponential",
+                    "model_kind": "depth_exponential_with_maximum",
                     "model_params":
                     {
                         "porosity_a": 0.84,
@@ -89,7 +89,7 @@ def test_read_legacy_rpi_config_jdf(fixture_dir):
                 },
                 "compressibility":
                 {
-                    "model_kind": "overburden_compressibility",
+                    "model_kind": "overburden",
                     "model_params":
                     {
                         "a": 0.09,
@@ -126,7 +126,7 @@ def test_read_legacy_rpi_config_jdf(fixture_dir):
                 },
                 "conductivity":
                 {
-                    "model_kind": "porosity_weighted_conductivity",
+                    "model_kind": "porosity_weighted",
                     "model_params":
                     {
                         "water_conductivity": 0.62,
@@ -177,7 +177,7 @@ def test_read_legacy_rpi_config_jdf(fixture_dir):
                 },
                 "conductivity":
                 {
-                    "model_kind": "porosity_weighted_conductivity",
+                    "model_kind": "porosity_weighted",
                     "model_params":
                     {
                         "water_conductivity": 0.62,
@@ -228,7 +228,7 @@ def test_read_legacy_rpi_config_jdf(fixture_dir):
                 },
                 "conductivity":
                 {
-                    "model_kind": "porosity_weighted_conductivity",
+                    "model_kind": "porosity_weighted",
                     "model_params":
                     {
                         "water_conductivity": 0.62,
@@ -279,7 +279,7 @@ def test_read_legacy_rpi_config_jdf(fixture_dir):
                 },
                 "conductivity":
                 {
-                    "model_kind": "porosity_weighted_conductivity",
+                    "model_kind": "porosity_weighted",
                     "model_params":
                     {
                         "water_conductivity": 0.62,
@@ -339,7 +339,7 @@ def test_read_legacy_rpi_config_np(fixture_dir):
                 },
                 "conductivity":
                 {
-                    "model_kind": "porosity_weighted_conductivity",
+                    "model_kind": "porosity_weighted",
                     "model_params":
                     {
                         "water_conductivity": 0.62,
@@ -357,7 +357,7 @@ def test_read_legacy_rpi_config_np(fixture_dir):
                 },
                 "compressibility":
                 {
-                    "model_kind": "overburden_compressibility",
+                    "model_kind": "overburden",
                     "model_params":
                     {
                         "a": 0.09,
@@ -394,7 +394,7 @@ def test_read_legacy_rpi_config_np(fixture_dir):
                 },
                 "conductivity":
                 {
-                    "model_kind": "porosity_weighted_conductivity",
+                    "model_kind": "porosity_weighted",
                     "model_params":
                     {
                         "water_conductivity": 0.62,
@@ -445,7 +445,7 @@ def test_read_legacy_rpi_config_np(fixture_dir):
                 },
                 "conductivity":
                 {
-                    "model_kind": "porosity_weighted_conductivity",
+                    "model_kind": "porosity_weighted",
                     "model_params":
                     {
                         "water_conductivity": 0.62,
@@ -496,7 +496,7 @@ def test_read_legacy_rpi_config_np(fixture_dir):
                 },
                 "conductivity":
                 {
-                    "model_kind": "porosity_weighted_conductivity",
+                    "model_kind": "porosity_weighted",
                     "model_params":
                     {
                         "water_conductivity": 0.62,
@@ -547,7 +547,7 @@ def test_read_legacy_rpi_config_np(fixture_dir):
                 },
                 "conductivity":
                 {
-                    "model_kind": "porosity_weighted_conductivity",
+                    "model_kind": "porosity_weighted",
                     "model_params":
                     {
                         "water_conductivity": 0.62,
@@ -598,7 +598,7 @@ def test_read_legacy_rpi_config_np(fixture_dir):
                 },
                 "conductivity":
                 {
-                    "model_kind": "porosity_weighted_conductivity",
+                    "model_kind": "porosity_weighted",
                     "model_params":
                     {
                         "water_conductivity": 0.62,


### PR DESCRIPTION
This splits out the various property models from the main `rockprop` code and places them into the `property_models` package. I also did some mild refactoring of the way we access property models within other models to be more explicit and avoid circular imports.