### PR TITLE
Allow overlapping zones

### DIFF
--- a/fehm_toolkit/config/rpi_reader.py
+++ b/fehm_toolkit/config/rpi_reader.py
@@ -42,6 +42,7 @@ def read_legacy_rpi_config(rpi_file: Path) -> dict:
 
 def convert_to_zone_lookup_format(config):
     reformatted_properties = defaultdict(dict)
+    zone_order = []
     for property_kind, block_configs in config['rock_properties'].items():
         for block_config in block_configs:
             for zone in block_config['zones']:
@@ -49,7 +50,15 @@ def convert_to_zone_lookup_format(config):
                     'model_kind': block_config['model_kind'],
                     'model_params': block_config['model_params'],
                 }
-    return {'rock_properties': reformatted_properties}
+                if zone not in zone_order:
+                    zone_order.append(zone)
+
+    return {
+        'rock_properties': {
+            'zone_assignment_order': zone_order,
+            'zone_configs_by_zone': reformatted_properties,
+        },
+    }
 
 
 def _read_and_process_rpi(rpi_file: Path) -> dict[str, str]:

--- a/fehm_toolkit/rock_properties.py
+++ b/fehm_toolkit/rock_properties.py
@@ -36,7 +36,6 @@ def generate_rock_properties_files(
         read_elements=False,
     )
     _validate_config_all_zones_covered(rock_properties_config, zones=grid.material_zones)
-    _validate_no_zone_overlap(grid)
 
     property_lookups = {}
     for zone, zone_config in rock_properties_config.items():
@@ -97,16 +96,6 @@ def _validate_config_all_zones_covered(config: dict, zones: tuple[int]):
         mismatched_property_kinds = zone_config.keys() ^ PROPERTY_KINDS
         if mismatched_property_kinds:
             raise ValueError(f'Mismatched property kinds in zone {zone}: {mismatched_property_kinds}')
-
-
-def _validate_no_zone_overlap(grid: Grid):
-    node_sets = []
-    for zone in grid.material_zones:
-        nodes = set(node.number for node in grid.get_nodes_in_material_zone(zone))
-        node_sets.append(nodes)
-    intersect = set.intersection(*node_sets)
-    if intersect:
-        raise NotImplementedError(f'No support for overlapping zones. Overlap found at nodes: {intersect}.')
 
 
 def _validate_all_nodes_covered(property_lookups: dict, n_nodes: int):

--- a/test/config/test_legacy_readers.py
+++ b/test/config/test_legacy_readers.py
@@ -28,294 +28,297 @@ def test_read_legacy_rpi_config_jdf(fixture_dir):
     assert config == {
         "rock_properties":
         {
-            1: {
-                "porosity":
-                {
-                    "model_kind": "depth_exponential_with_maximum",
-                    "model_params":
+            "zone_assignment_order": [1, 2, 3, 4, 5],
+            "zone_configs_by_zone": {
+                1: {
+                    "porosity":
                     {
-                        "porosity_a": 0.84,
-                        "porosity_b": -0.125
-                    }
-                },
-                "conductivity":
-                {
-                    "model_kind": "ctr2tcon",
-                    "model_params":
-                    {
-                        "node_depth_columns":
-                        [
-                            [
-                                0,
-                                100,
-                                200,
-                                300,
-                                425,
-                                450
-                            ],
-                            [
-                                0,
-                                200,
-                                425,
-                                450
-                            ],
-                            [
-                                0,
-                                425,
-                                450
-                            ]
-                        ],
-                        "ctr_model":
+                        "model_kind": "depth_exponential_with_maximum",
+                        "model_params":
                         {
-                            "model_kind": "polynomial",
-                            "model_params":
+                            "porosity_a": 0.84,
+                            "porosity_b": -0.125
+                        }
+                    },
+                    "conductivity":
+                    {
+                        "model_kind": "ctr2tcon",
+                        "model_params":
+                        {
+                            "node_depth_columns":
+                            [
+                                [
+                                    0,
+                                    100,
+                                    200,
+                                    300,
+                                    425,
+                                    450
+                                ],
+                                [
+                                    0,
+                                    200,
+                                    425,
+                                    450
+                                ],
+                                [
+                                    0,
+                                    425,
+                                    450
+                                ]
+                            ],
+                            "ctr_model":
                             {
-                                "x^0": 0,
-                                "x^1": 0.603,
-                                "x^2": 0.000531,
-                                "x^3": -6.84E-7
+                                "model_kind": "polynomial",
+                                "model_params":
+                                {
+                                    "x^0": 0,
+                                    "x^1": 0.603,
+                                    "x^2": 0.000531,
+                                    "x^3": -6.84E-7
+                                }
                             }
+                        }
+                    },
+                    "permeability":
+                    {
+                        "model_kind": "void_ratio_power_law",
+                        "model_params":
+                        {
+                            "A": 3.66E-18,
+                            "B": 1.68
+                        }
+                    },
+                    "compressibility":
+                    {
+                        "model_kind": "overburden",
+                        "model_params":
+                        {
+                            "a": 0.09,
+                            "grav": 9.81,
+                            "rhow": 1000.0,
+                            "min_overburden": 25.0
+                        }
+                    },
+                    "grain_density":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 2650.0
+                        }
+                    },
+                    "specific_heat":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 800.0
                         }
                     }
                 },
-                "permeability":
-                {
-                    "model_kind": "void_ratio_power_law",
-                    "model_params":
+                2: {
+                    "porosity":
                     {
-                        "A": 3.66E-18,
-                        "B": 1.68
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 0.1
+                        }
+                    },
+                    "conductivity":
+                    {
+                        "model_kind": "porosity_weighted",
+                        "model_params":
+                        {
+                            "water_conductivity": 0.62,
+                            "rock_conductivity": 2.05
+                        }
+                    },
+                    "permeability":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 1E-12
+                        }
+                    },
+                    "compressibility":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 6E-10
+                        }
+                    },
+                    "grain_density":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 2700.0
+                        }
+                    },
+                    "specific_heat":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 800.0
+                        }
                     }
                 },
-                "compressibility":
-                {
-                    "model_kind": "overburden",
-                    "model_params":
+                3: {
+                    "porosity":
                     {
-                        "a": 0.09,
-                        "grav": 9.81,
-                        "rhow": 1000.0,
-                        "min_overburden": 25.0
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 0.1
+                        }
+                    },
+                    "conductivity":
+                    {
+                        "model_kind": "porosity_weighted",
+                        "model_params":
+                        {
+                            "water_conductivity": 0.62,
+                            "rock_conductivity": 2.05
+                        }
+                    },
+                    "permeability":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 1E-12
+                        }
+                    },
+                    "compressibility":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 6E-10
+                        }
+                    },
+                    "grain_density":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 2700.0
+                        }
+                    },
+                    "specific_heat":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 800.0
+                        }
                     }
                 },
-                "grain_density":
-                {
-                    "model_kind": "constant",
-                    "model_params":
+                4: {
+                    "porosity":
                     {
-                        "constant": 2650.0
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 0.1
+                        }
+                    },
+                    "conductivity":
+                    {
+                        "model_kind": "porosity_weighted",
+                        "model_params":
+                        {
+                            "water_conductivity": 0.62,
+                            "rock_conductivity": 2.05
+                        }
+                    },
+                    "permeability":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 1E-12
+                        }
+                    },
+                    "compressibility":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 6E-10
+                        }
+                    },
+                    "grain_density":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 2700.0
+                        }
+                    },
+                    "specific_heat":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 800.0
+                        }
                     }
                 },
-                "specific_heat":
-                {
-                    "model_kind": "constant",
-                    "model_params":
+                5: {
+                    "porosity":
                     {
-                        "constant": 800.0
-                    }
-                }
-            },
-            2: {
-                "porosity":
-                {
-                    "model_kind": "constant",
-                    "model_params":
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 0.05
+                        }
+                    },
+                    "conductivity":
                     {
-                        "constant": 0.1
-                    }
-                },
-                "conductivity":
-                {
-                    "model_kind": "porosity_weighted",
-                    "model_params":
+                        "model_kind": "porosity_weighted",
+                        "model_params":
+                        {
+                            "water_conductivity": 0.62,
+                            "rock_conductivity": 2.05
+                        }
+                    },
+                    "permeability":
                     {
-                        "water_conductivity": 0.62,
-                        "rock_conductivity": 2.05
-                    }
-                },
-                "permeability":
-                {
-                    "model_kind": "constant",
-                    "model_params":
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 1E-18
+                        }
+                    },
+                    "compressibility":
                     {
-                        "constant": 1E-12
-                    }
-                },
-                "compressibility":
-                {
-                    "model_kind": "constant",
-                    "model_params":
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 6E-10
+                        }
+                    },
+                    "grain_density":
                     {
-                        "constant": 6E-10
-                    }
-                },
-                "grain_density":
-                {
-                    "model_kind": "constant",
-                    "model_params":
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 2700.0
+                        }
+                    },
+                    "specific_heat":
                     {
-                        "constant": 2700.0
-                    }
-                },
-                "specific_heat":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 800.0
-                    }
-                }
-            },
-            3: {
-                "porosity":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 0.1
-                    }
-                },
-                "conductivity":
-                {
-                    "model_kind": "porosity_weighted",
-                    "model_params":
-                    {
-                        "water_conductivity": 0.62,
-                        "rock_conductivity": 2.05
-                    }
-                },
-                "permeability":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 1E-12
-                    }
-                },
-                "compressibility":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 6E-10
-                    }
-                },
-                "grain_density":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 2700.0
-                    }
-                },
-                "specific_heat":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 800.0
-                    }
-                }
-            },
-            4: {
-                "porosity":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 0.1
-                    }
-                },
-                "conductivity":
-                {
-                    "model_kind": "porosity_weighted",
-                    "model_params":
-                    {
-                        "water_conductivity": 0.62,
-                        "rock_conductivity": 2.05
-                    }
-                },
-                "permeability":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 1E-12
-                    }
-                },
-                "compressibility":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 6E-10
-                    }
-                },
-                "grain_density":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 2700.0
-                    }
-                },
-                "specific_heat":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 800.0
-                    }
-                }
-            },
-            5: {
-                "porosity":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 0.05
-                    }
-                },
-                "conductivity":
-                {
-                    "model_kind": "porosity_weighted",
-                    "model_params":
-                    {
-                        "water_conductivity": 0.62,
-                        "rock_conductivity": 2.05
-                    }
-                },
-                "permeability":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 1E-18
-                    }
-                },
-                "compressibility":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 6E-10
-                    }
-                },
-                "grain_density":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 2700.0
-                    }
-                },
-                "specific_heat":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 800.0
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 800.0
+                        }
                     }
                 }
             }
@@ -328,313 +331,316 @@ def test_read_legacy_rpi_config_np(fixture_dir):
     assert config == {
         "rock_properties":
         {
-            1: {
-                "porosity":
-                {
-                    "model_kind": "constant",
-                    "model_params":
+            "zone_assignment_order": [1, 2, 3, 4, 5, 6],
+            "zone_configs_by_zone": {
+                1: {
+                    "porosity":
                     {
-                        "constant": 0.62
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 0.62
+                        }
+                    },
+                    "conductivity":
+                    {
+                        "model_kind": "porosity_weighted",
+                        "model_params":
+                        {
+                            "water_conductivity": 0.62,
+                            "rock_conductivity": 2.6
+                        }
+                    },
+                    "permeability":
+                    {
+                        "model_kind": "void_ratio_power_law",
+                        "model_params":
+                        {
+                            "A": 1.1E-17,
+                            "B": 2.2
+                        }
+                    },
+                    "compressibility":
+                    {
+                        "model_kind": "overburden",
+                        "model_params":
+                        {
+                            "a": 0.09,
+                            "grav": 9.81,
+                            "rhow": 1000.0,
+                            "min_overburden": 25.0
+                        }
+                    },
+                    "grain_density":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 2650.0
+                        }
+                    },
+                    "specific_heat":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 800.0
+                        }
                     }
                 },
-                "conductivity":
-                {
-                    "model_kind": "porosity_weighted",
-                    "model_params":
+                2: {
+                    "porosity":
                     {
-                        "water_conductivity": 0.62,
-                        "rock_conductivity": 2.6
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 0.1
+                        }
+                    },
+                    "conductivity":
+                    {
+                        "model_kind": "porosity_weighted",
+                        "model_params":
+                        {
+                            "water_conductivity": 0.62,
+                            "rock_conductivity": 2.05
+                        }
+                    },
+                    "permeability":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 1E-15
+                        }
+                    },
+                    "compressibility":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 6E-10
+                        }
+                    },
+                    "grain_density":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 2700.0
+                        }
+                    },
+                    "specific_heat":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 800.0
+                        }
                     }
                 },
-                "permeability":
-                {
-                    "model_kind": "void_ratio_power_law",
-                    "model_params":
+                3: {
+                    "porosity":
                     {
-                        "A": 1.1E-17,
-                        "B": 2.2
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 0.08
+                        }
+                    },
+                    "conductivity":
+                    {
+                        "model_kind": "porosity_weighted",
+                        "model_params":
+                        {
+                            "water_conductivity": 0.62,
+                            "rock_conductivity": 2.05
+                        }
+                    },
+                    "permeability":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 1E-15
+                        }
+                    },
+                    "compressibility":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 6E-10
+                        }
+                    },
+                    "grain_density":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 2700.0
+                        }
+                    },
+                    "specific_heat":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 800.0
+                        }
                     }
                 },
-                "compressibility":
-                {
-                    "model_kind": "overburden",
-                    "model_params":
+                4: {
+                    "porosity":
                     {
-                        "a": 0.09,
-                        "grav": 9.81,
-                        "rhow": 1000.0,
-                        "min_overburden": 25.0
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 0.05
+                        }
+                    },
+                    "conductivity":
+                    {
+                        "model_kind": "porosity_weighted",
+                        "model_params":
+                        {
+                            "water_conductivity": 0.62,
+                            "rock_conductivity": 2.05
+                        }
+                    },
+                    "permeability":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 1E-15
+                        }
+                    },
+                    "compressibility":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 6E-10
+                        }
+                    },
+                    "grain_density":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 2700.0
+                        }
+                    },
+                    "specific_heat":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 800.0
+                        }
                     }
                 },
-                "grain_density":
-                {
-                    "model_kind": "constant",
-                    "model_params":
+                5: {
+                    "porosity":
                     {
-                        "constant": 2650.0
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 0.02
+                        }
+                    },
+                    "conductivity":
+                    {
+                        "model_kind": "porosity_weighted",
+                        "model_params":
+                        {
+                            "water_conductivity": 0.62,
+                            "rock_conductivity": 2.05
+                        }
+                    },
+                    "permeability":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 1E-17
+                        }
+                    },
+                    "compressibility":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 6E-10
+                        }
+                    },
+                    "grain_density":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 2700.0
+                        }
+                    },
+                    "specific_heat":
+                    {
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 800.0
+                        }
                     }
                 },
-                "specific_heat":
-                {
-                    "model_kind": "constant",
-                    "model_params":
+                6: {
+                    "porosity":
                     {
-                        "constant": 800.0
-                    }
-                }
-            },
-            2: {
-                "porosity":
-                {
-                    "model_kind": "constant",
-                    "model_params":
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 0.01
+                        }
+                    },
+                    "conductivity":
                     {
-                        "constant": 0.1
-                    }
-                },
-                "conductivity":
-                {
-                    "model_kind": "porosity_weighted",
-                    "model_params":
+                        "model_kind": "porosity_weighted",
+                        "model_params":
+                        {
+                            "water_conductivity": 0.62,
+                            "rock_conductivity": 2.05
+                        }
+                    },
+                    "permeability":
                     {
-                        "water_conductivity": 0.62,
-                        "rock_conductivity": 2.05
-                    }
-                },
-                "permeability":
-                {
-                    "model_kind": "constant",
-                    "model_params":
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 1E-17
+                        }
+                    },
+                    "compressibility":
                     {
-                        "constant": 1E-15
-                    }
-                },
-                "compressibility":
-                {
-                    "model_kind": "constant",
-                    "model_params":
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 6E-10
+                        }
+                    },
+                    "grain_density":
                     {
-                        "constant": 6E-10
-                    }
-                },
-                "grain_density":
-                {
-                    "model_kind": "constant",
-                    "model_params":
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 2700.0
+                        }
+                    },
+                    "specific_heat":
                     {
-                        "constant": 2700.0
-                    }
-                },
-                "specific_heat":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 800.0
-                    }
-                }
-            },
-            3: {
-                "porosity":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 0.08
-                    }
-                },
-                "conductivity":
-                {
-                    "model_kind": "porosity_weighted",
-                    "model_params":
-                    {
-                        "water_conductivity": 0.62,
-                        "rock_conductivity": 2.05
-                    }
-                },
-                "permeability":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 1E-15
-                    }
-                },
-                "compressibility":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 6E-10
-                    }
-                },
-                "grain_density":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 2700.0
-                    }
-                },
-                "specific_heat":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 800.0
-                    }
-                }
-            },
-            4: {
-                "porosity":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 0.05
-                    }
-                },
-                "conductivity":
-                {
-                    "model_kind": "porosity_weighted",
-                    "model_params":
-                    {
-                        "water_conductivity": 0.62,
-                        "rock_conductivity": 2.05
-                    }
-                },
-                "permeability":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 1E-15
-                    }
-                },
-                "compressibility":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 6E-10
-                    }
-                },
-                "grain_density":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 2700.0
-                    }
-                },
-                "specific_heat":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 800.0
-                    }
-                }
-            },
-            5: {
-                "porosity":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 0.02
-                    }
-                },
-                "conductivity":
-                {
-                    "model_kind": "porosity_weighted",
-                    "model_params":
-                    {
-                        "water_conductivity": 0.62,
-                        "rock_conductivity": 2.05
-                    }
-                },
-                "permeability":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 1E-17
-                    }
-                },
-                "compressibility":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 6E-10
-                    }
-                },
-                "grain_density":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 2700.0
-                    }
-                },
-                "specific_heat":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 800.0
-                    }
-                }
-            },
-            6: {
-                "porosity":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 0.01
-                    }
-                },
-                "conductivity":
-                {
-                    "model_kind": "porosity_weighted",
-                    "model_params":
-                    {
-                        "water_conductivity": 0.62,
-                        "rock_conductivity": 2.05
-                    }
-                },
-                "permeability":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 1E-17
-                    }
-                },
-                "compressibility":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 6E-10
-                    }
-                },
-                "grain_density":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 2700.0
-                    }
-                },
-                "specific_heat":
-                {
-                    "model_kind": "constant",
-                    "model_params":
-                    {
-                        "constant": 800.0
+                        "model_kind": "constant",
+                        "model_params":
+                        {
+                            "constant": 800.0
+                        }
                     }
                 }
             }


### PR DESCRIPTION
I had previously made the assumption that zones would have no overlap (based on how things are constructed in LaGrit). After a conversation with Andy during my visit, we identified the requirement to add additional zones, some of which overlap.

This PR removes the validator for asserting no zone overlap, and adds an explicit assignment order for zones so that properties are assigned in that way. This is necessary because we are no longer simply executing code from the top of the file to the bottom, so the expected order needs to be specified explicitly. When running from a legacy .rpi, this will execute in the order zones are first encountered.