### PR TITLE
Create restart

### DIFF
--- a/fehm_toolkit/file_interface/avs.py
+++ b/fehm_toolkit/file_interface/avs.py
@@ -12,10 +12,10 @@ SUPPORTED_FIELDS = {
 }
 
 
-def read_avs(restart_file: Path) -> tuple[State, dict]:
+def read_avs(avs_file: Path) -> tuple[State, dict]:
     """Loads AVS contour files (.avs) into memory as a model State."""
 
-    with open(restart_file) as f:
+    with open(avs_file) as f:
         metadata = [int(value) for value in next(f).strip().split()]
         n_columns, column_dimensions = metadata[0], metadata[1:]
         if any(dim > 1 for dim in column_dimensions):
@@ -26,7 +26,10 @@ def read_avs(restart_file: Path) -> tuple[State, dict]:
         fields_to_save = [field for field in field_names if field in SUPPORTED_FIELDS]
 
         for line in f:
-            row = {field_name: Decimal(value) for field_name, value in zip(field_names, line.strip().split())}
+            row = {
+                field_name: round(Decimal(value), 10)
+                for field_name, value in zip(field_names, line.strip().split())
+            }
             for field_name in fields_to_save:
                 avs_data[field_name].append(row[field_name])
 

--- a/fehm_toolkit/utilities/__init__.py
+++ b/fehm_toolkit/utilities/__init__.py
@@ -1,1 +1,2 @@
 from .append_zones import append_zones
+from .create_restart import create_restart_from_avs, create_restart_from_restart

--- a/fehm_toolkit/utilities/append_zones.py
+++ b/fehm_toolkit/utilities/append_zones.py
@@ -1,12 +1,12 @@
 from pathlib import Path
-from typing import Iterable, Union
+from typing import Sequence, Union
 
 from ..fehm_objects import Zone
 from ..file_interface import read_zones
 
 
 def append_zones(
-    zone_keys_to_add: Iterable[Union[int, str]],
+    zone_keys_to_add: Sequence[Union[int, str]],
     add_zones_from_file: Path,
     add_zones_to_file: Path,
 ):
@@ -14,7 +14,7 @@ def append_zones(
     return _combine_zones(zones_to_add=zones_to_add, source_zones=read_zones(add_zones_to_file))
 
 
-def _filter_zones_to_add(zone_keys_to_add: Iterable[Union[int, str]], raw_zones_to_add: tuple[Zone]) -> tuple[Zone]:
+def _filter_zones_to_add(zone_keys_to_add: Sequence[Union[int, str]], raw_zones_to_add: tuple[Zone]) -> tuple[Zone]:
     return (zone for zone in raw_zones_to_add if zone.number in zone_keys_to_add or zone.name in zone_keys_to_add)
 
 

--- a/fehm_toolkit/utilities/create_restart.py
+++ b/fehm_toolkit/utilities/create_restart.py
@@ -1,0 +1,51 @@
+import dataclasses
+from pathlib import Path
+
+from ..fehm_objects import RestartMetadata, State
+from ..file_interface import read_avs, read_restart
+
+
+def create_restart_from_restart(
+    base_restart_file: Path,
+    reset_model_time: bool = True,
+) -> tuple[State, RestartMetadata]:
+    state, metadata = read_restart(base_restart_file)
+
+    if reset_model_time:
+        metadata = dataclasses.replace(metadata, simulation_time_days=0)
+
+    return state, metadata
+
+
+def create_restart_from_avs(
+    avs_file: Path,
+    base_restart_file: Path,
+    reset_model_time: bool = True,
+) -> tuple[State, RestartMetadata]:
+    """Creates a new restart (State, RestartMetadata) from AVS data.
+
+    Pressure and Temperature data come from `avs_file`, while other properties and RestartMetadata are pulled
+    from an existing restart file (.ini, .fin).
+    """
+    base_restart_state, metadata = read_restart(base_restart_file)
+    avs_state = read_avs(avs_file)
+    combined = _combine_state(avs_state, other=base_restart_state, property_kind_from_other='saturations')
+
+    if reset_model_time:
+        metadata = dataclasses.replace(metadata, simulation_time_days=0)
+
+    return combined, metadata
+
+
+def _combine_state(
+    state: State,
+    other: State,
+    property_kind_from_other: str,
+) -> State:
+    if property_kind_from_other not in {f.name for f in dataclasses.fields(State)}:
+        raise ValueError(f'property_kind {property_kind_from_other} is not supported by State')
+
+    new_values = dataclasses.asdict(other)[property_kind_from_other]
+    new_state = dataclasses.replace(state, **{property_kind_from_other: new_values})
+    new_state.validate()
+    return new_state

--- a/test/end_to_end/test_written_files.py
+++ b/test/end_to_end/test_written_files.py
@@ -144,7 +144,6 @@ def test_create_restart_from_restart_against_fixture(tmp_path, matlab_fixture_di
     state, metadata = create_restart_from_restart(model_dir / f'{model_root}.fin', reset_model_time=True)
 
     output_file = tmp_path / 'test.fin'
-    # output_file = '/Users/dustin/Desktop/test.ini'
     fixture_file = model_dir / 'fin2ini_fixture_1.ini'
 
     write_restart(state, metadata, output_file=output_file)

--- a/test/end_to_end/test_written_files.py
+++ b/test/end_to_end/test_written_files.py
@@ -2,10 +2,10 @@ import logging
 
 import pytest
 
-from fehm_toolkit.file_interface import write_zones
+from fehm_toolkit.file_interface import write_restart, write_zones
 from fehm_toolkit.heat_in import generate_input_heatflux_file
 from fehm_toolkit.rock_properties import generate_rock_properties_files
-from fehm_toolkit.utilities import append_zones
+from fehm_toolkit.utilities import append_zones, create_restart_from_avs, create_restart_from_restart
 
 logger = logging.getLogger(__name__)
 
@@ -116,3 +116,37 @@ def test_append_zones_against_fixture(tmpdir, matlab_fixture_dir, model_name, mo
         actual = output_file.read()
 
     assert actual == expected
+
+
+def test_create_restart_from_avs_against_fixture(tmp_path, matlab_fixture_dir):
+    model_dir = matlab_fixture_dir / 'jdf2d_p12'
+    state, metadata = create_restart_from_avs(
+        avs_file=model_dir / 'p12.00014_sca_node.avs',
+        base_restart_file=model_dir / 'p12.ini',
+    )
+    output_file = tmp_path / 'test.fin'
+    fixture_file = model_dir / 'avs2fin_fixture.fin'
+
+    write_restart(state, metadata, output_file=output_file)
+
+    assert output_file.read_text() == fixture_file.read_text()
+
+
+@pytest.mark.parametrize(
+    'model_name, model_root', (
+        # TODO(dustin): replace these with small custom grids
+        ('np2d_cond', 'cond'),
+        ('jdf2d_p12', 'p12'),
+    )
+)
+def test_create_restart_from_restart_against_fixture(tmp_path, matlab_fixture_dir, model_name, model_root):
+    model_dir = matlab_fixture_dir / model_name
+    state, metadata = create_restart_from_restart(model_dir / f'{model_root}.fin', reset_model_time=True)
+
+    output_file = tmp_path / 'test.fin'
+    # output_file = '/Users/dustin/Desktop/test.ini'
+    fixture_file = model_dir / 'fin2ini_fixture_1.ini'
+
+    write_restart(state, metadata, output_file=output_file)
+
+    assert output_file.read_text() == fixture_file.read_text()


### PR DESCRIPTION
This PR creates a new utility to match fin2ini called `create_restart`. "Restart" is the name FEHM uses to refer to the ini/fin files (`rsti`/`rsto` in the .files file). This utility creates a new restart based on an existing `State` object that can be read in from any supported format (e.g. ini/fin/avs/iap/icp). Just like the Matlab version, this supports zeroing the time.