### PR TITLE
Singular state names

### DIFF
--- a/fehm_toolkit/fehm_objects/state.py
+++ b/fehm_toolkit/fehm_objects/state.py
@@ -6,21 +6,21 @@ from typing import Optional, Sequence
 @dataclass
 class State:
     """Class representing a snapshotted model state."""
-    temperatures: Sequence[float]
-    pressures: Sequence[float]
-    saturations: Optional[Sequence[float]] = None
-    sources: Optional[Sequence[float]] = None
-    mass_fluxes: Optional[Sequence[float]] = None
+    temperature: Sequence[Decimal]
+    pressure: Sequence[Decimal]
+    saturation: Optional[Sequence[Decimal]] = None
+    source: Optional[Sequence[Decimal]] = None
+    mass_flux: Optional[Sequence[Decimal]] = None
 
     def __post_init__(self):
         self.validate()
 
     def validate(self):
-        n_temperatures = len(self.temperatures)
+        n_temps = len(self.temperature)
         for field, data in self.__dict__.items():
-            if data is not None and len(data) != n_temperatures:
+            if data is not None and len(data) != n_temps:
                 raise ValueError(
-                    f'Number of {field} ({len(data)}) does not match the number of temperatures ({n_temperatures})'
+                    f'Number of {field} ({len(data)}) does not match the number of temperatures ({n_temps})'
                 )
 
 

--- a/fehm_toolkit/file_interface/avs.py
+++ b/fehm_toolkit/file_interface/avs.py
@@ -12,7 +12,7 @@ SUPPORTED_FIELDS = {
 }
 
 
-def read_avs(avs_file: Path) -> tuple[State, dict]:
+def read_avs(avs_file: Path) -> State:
     """Loads AVS contour files (.avs) into memory as a model State."""
 
     with open(avs_file) as f:

--- a/fehm_toolkit/file_interface/avs.py
+++ b/fehm_toolkit/file_interface/avs.py
@@ -5,10 +5,10 @@ from pathlib import Path
 from fehm_toolkit.fehm_objects import State
 
 SUPPORTED_FIELDS = {
-    'Liquid Pressure (MPa), (MPa)': 'pressures',
-    'Temperature (deg C), (deg C)': 'temperatures',
-    'Source (kg/s), (kg/s)': 'sources',
-    'Liquid Flux (kg/s), (kg/s)': 'mass_fluxes',
+    'Liquid Pressure (MPa), (MPa)': 'pressure',
+    'Temperature (deg C), (deg C)': 'temperature',
+    'Source (kg/s), (kg/s)': 'source',
+    'Liquid Flux (kg/s), (kg/s)': 'mass_flux',
 }
 
 

--- a/fehm_toolkit/file_interface/restart.py
+++ b/fehm_toolkit/file_interface/restart.py
@@ -29,9 +29,9 @@ def read_restart(restart_file: Path) -> tuple[State, RestartMetadata]:
 
     try:
         state = State(
-            temperatures=values_by_block['temperature'],
-            saturations=values_by_block['saturation'],
-            pressures=values_by_block['pressure'],
+            temperature=values_by_block['temperature'],
+            saturation=values_by_block['saturation'],
+            pressure=values_by_block['pressure'],
         )
     except KeyError:
         raise KeyError(f'Required block "{block_name}" not found in restart file {restart_file}.')
@@ -121,10 +121,10 @@ def _write_block_legacy_format(open_file: TextIO, block_name: str, block_data: S
 
 def _get_data_for_block(block_name: str, state: State) -> Sequence:
     if block_name == 'temperature':
-        return state.temperatures
+        return state.temperature
     elif block_name == 'pressure':
-        return state.pressures
+        return state.pressure
     elif block_name == 'saturation':
-        return state.saturations
+        return state.saturation
     else:
         raise NotImplementedError(f'Block kind "{block_name}" not supported.')

--- a/fehm_toolkit/file_interface/restart.py
+++ b/fehm_toolkit/file_interface/restart.py
@@ -53,7 +53,7 @@ def _parse_nodes_header(nodes_header: str) -> int:
     return int(header_items[0]), keyword
 
 
-def _parse_scalar_block(open_file: TextIO, n_nodes: int) -> tuple[float]:
+def _parse_scalar_block(open_file: TextIO, n_nodes: int) -> list[Decimal]:
     scalar_values = []
     while len(scalar_values) < n_nodes:
         line = next(open_file)

--- a/test/file_interface/test_file_readers.py
+++ b/test/file_interface/test_file_readers.py
@@ -101,17 +101,17 @@ def test_read_simple_restart_legacy_format(fixture_dir):
         dual_porosity_permeability_keyword='nddp',
     )
     assert state == State(
-        temperatures=[
+        temperature=[
             Decimal(v) for v in (
                 '35.3103156449', '26.3715674828', '26.6993730893', '13.7232584411', '13.4748018922', '9.9921394765',
             )
         ],
-        saturations=[
+        saturation=[
             Decimal(v) for v in (
                 '1.0000000000', '1.0000000000', '1.0000000000', '1.0000000000', '1.0000000000', '1.0000000000',
             )
         ],
-        pressures=[
+        pressure=[
             Decimal(v) for v in (
                 '46.1720206040', '45.6706062299', '45.6811178622', '45.4069398347', '45.3847810418', '45.1548391299',
             )
@@ -129,14 +129,14 @@ def test_read_simple_restart_fehm_format(fixture_dir):
         dual_porosity_permeability_keyword='nddp',
     )
     assert state == State(
-        temperatures=[
+        temperature=[
             Decimal(v) for v in (
                 '9.482060132451755', '14.20269570985147', '8.414855364338784', '69.80068704764734',
                 '86.91250913933038', '85.88408430521636', '69.38671894047677', '68.56111995201577',
             )
         ],
-        saturations=8 * [Decimal('1.000000000000000')],
-        pressures=[
+        saturation=8 * [Decimal('1.000000000000000')],
+        pressure=[
             Decimal(v) for v in (
                 '33.69520926926931', '33.69378317097816', '31.45654762003292', '36.15766656073081',
                 '37.61776959952319', '37.61945828718319', '36.15826817848320', '34.69600450690525',
@@ -156,21 +156,21 @@ def test_read_tracer_restart(fixture_dir):
         unsupported_blocks=True,
     )
     assert state == State(
-        temperatures=[
+        temperature=[
             Decimal(v) for v in (
                 '34.99999999987494', '34.99999999987494', '29.99740954219060', '29.99740954219060',
                 '24.99481908388880', '24.99481908388880', '19.99222863160355', '19.99222863160355',
                 '14.99935303204482', '14.99935303204482', '10.00000000012507', '10.00000000012507',
             )
         ],
-        saturations=[
+        saturation=[
             Decimal(v) for v in (
                 '0.1000000000000000E-98', '0.1000000000000000E-98', '0.1000000000000000E-98', '0.1000000000000000E-98',
                 '0.1000000000000000E-98', '0.1000000000000000E-98', '0.1727371363921276', '0.1727371363921281',
                 '0.4344871249926068', '0.4344871249926068', '0.7817833455822488', '0.7817833455822516',
             )
         ],
-        pressures=[
+        pressure=[
             Decimal(v) for v in (
                 '0.1001154694602094', '0.1001154694602094', '0.1001154694628803', '0.1001154694628803',
                 '0.1001154694707533', '0.1001154694707533', '0.1001154694901246', '0.1001154694901246',
@@ -183,10 +183,10 @@ def test_read_tracer_restart(fixture_dir):
 def test_read_avs_simple_scalar(fixture_dir):
     state = read_avs(fixture_dir / 'simple_sca_node.avs')
     assert state == State(
-        temperatures=[Decimal(v) for v in ('9.48206013', '14.2026957', '8.41485536', '69.8006870')],
-        pressures=[Decimal(v) for v in ('33.6952093', '33.6937832', '31.4565476', '36.1576666')],
-        sources=[Decimal(v) for v in (0, 0, 0, 0)],
-        mass_fluxes=[Decimal(v) for v in (0, 0, 0, 0)],
+        temperature=[Decimal(v) for v in ('9.48206013', '14.2026957', '8.41485536', '69.8006870')],
+        pressure=[Decimal(v) for v in ('33.6952093', '33.6937832', '31.4565476', '36.1576666')],
+        source=[Decimal(v) for v in (0, 0, 0, 0)],
+        mass_flux=[Decimal(v) for v in (0, 0, 0, 0)],
     )
 
 

--- a/test/file_interface/test_state.py
+++ b/test/file_interface/test_state.py
@@ -4,9 +4,9 @@ from fehm_toolkit.fehm_objects import State
 
 
 def test_state_same_length():
-    State(temperatures=[1, 2, 3], pressures=[0, 5, 6])
+    State(temperature=[1, 2, 3], pressure=[0, 5, 6])
 
 
 def test_state_different_length():
     with pytest.raises(ValueError):
-        State(temperatures=[1, 2, 3], pressures=[0, 5, 6], saturations=[0, 1])
+        State(temperature=[1, 2, 3], pressure=[0, 5, 6], saturation=[0, 1])


### PR DESCRIPTION
Revert to using singular attributes on `State` - e.g. `temperature` instead of `temperatures`. It seemed more accurate as plural but I keep using the wrong one so I thought I'd fix now before it's too endemic.