### PR TITLE
Control files

### DIFF
--- a/fehm_toolkit/utilities/__init__.py
+++ b/fehm_toolkit/utilities/__init__.py
@@ -1,2 +1,3 @@
 from .append_zones import append_zones
 from .create_restart import create_restart_from_avs, create_restart_from_restart
+from .modify_control_file import write_modified_control_file

--- a/fehm_toolkit/utilities/__init__.py
+++ b/fehm_toolkit/utilities/__init__.py
@@ -1,3 +1,3 @@
 from .append_zones import append_zones
 from .create_restart import create_restart_from_avs, create_restart_from_restart
-from .modify_control_file import write_modified_control_file
+from .modify_fehm_input_file import write_modified_fehm_input_file

--- a/fehm_toolkit/utilities/modify_control_file.py
+++ b/fehm_toolkit/utilities/modify_control_file.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+import re
+from typing import Optional
+
+
+def write_modified_control_file(
+    base_control_file: Path,
+    out_file: Path,
+    initial_timestep_days: float = None,
+    initial_simulation_time_days: float = None,
+    file_mapping: Optional[dict[str, str]] = None,
+) -> str:
+    """Write a control file (.dat) from the (modified) contents of another control file."""
+    control_content = base_control_file.read_text()
+    if file_mapping:
+        control_content = _replace_mapped_files(control_content, file_mapping)
+
+    if initial_timestep_days is not None or initial_simulation_time_days is not None:
+        control_content = _replace_timing(
+            control_content,
+            initial_timestep_days=initial_timestep_days,
+            initial_simulation_time_days=initial_simulation_time_days,
+        )
+
+    out_file.write_text(control_content)
+
+
+def _replace_mapped_files(content: str, file_mapping: dict[str, str]) -> str:
+    for initial_file, replace_file in file_mapping.items():
+        content = re.sub(
+            pattern=rf'(\s){initial_file}(\s)',
+            repl=lambda match: rf'{match.group(1)}{replace_file}{match.group(2)}',
+            string=content,
+        )
+    return content
+
+
+def _replace_timing(
+    content: str,
+    *,
+    initial_timestep_days: Optional[float],
+    initial_simulation_time_days: Optional[float],
+):
+
+    def _timing_string(match: re.Match):
+        time_args = match.group(1).strip().split()
+        if len(time_args) != 7:
+            raise ValueError(f'Unexpected number of arguments for "time" control statement ({len(time_args)})')
+        if initial_timestep_days is not None:
+            time_args[0] = str(initial_timestep_days)
+        if initial_simulation_time_days is not None:
+            time_args[6] = str(initial_simulation_time_days)
+        return 'time\n  ' + ' '.join(time_args) + '\n'
+
+    return re.sub(
+        pattern=r'time\n(.*)\n',
+        repl=_timing_string,
+        string=content,
+    )

--- a/fehm_toolkit/utilities/modify_fehm_input_file.py
+++ b/fehm_toolkit/utilities/modify_fehm_input_file.py
@@ -3,7 +3,7 @@ import re
 from typing import Optional
 
 
-def write_modified_control_file(
+def write_modified_fehm_input_file(
     base_control_file: Path,
     out_file: Path,
     initial_timestep_days: float = None,

--- a/fehm_toolkit/utilities/modify_fehm_input_file.py
+++ b/fehm_toolkit/utilities/modify_fehm_input_file.py
@@ -4,25 +4,25 @@ from typing import Optional
 
 
 def write_modified_fehm_input_file(
-    base_control_file: Path,
+    base_fehm_input_file: Path,
     out_file: Path,
     initial_timestep_days: float = None,
     initial_simulation_time_days: float = None,
     file_mapping: Optional[dict[str, str]] = None,
 ) -> str:
     """Write a control file (.dat) from the (modified) contents of another control file."""
-    control_content = base_control_file.read_text()
+    fehm_input_content = base_fehm_input_file.read_text()
     if file_mapping:
-        control_content = _replace_mapped_files(control_content, file_mapping)
+        fehm_input_content = _replace_mapped_files(fehm_input_content, file_mapping)
 
     if initial_timestep_days is not None or initial_simulation_time_days is not None:
-        control_content = _replace_timing(
-            control_content,
+        fehm_input_content = _replace_timing(
+            fehm_input_content,
             initial_timestep_days=initial_timestep_days,
             initial_simulation_time_days=initial_simulation_time_days,
         )
 
-    out_file.write_text(control_content)
+    out_file.write_text(fehm_input_content)
 
 
 def _replace_mapped_files(content: str, file_mapping: dict[str, str]) -> str:

--- a/test/end_to_end/test_written_files.py
+++ b/test/end_to_end/test_written_files.py
@@ -9,7 +9,7 @@ from fehm_toolkit.utilities import (
     append_zones,
     create_restart_from_avs,
     create_restart_from_restart,
-    write_modified_control_file,
+    write_modified_fehm_input_file,
 )
 
 logger = logging.getLogger(__name__)
@@ -185,12 +185,12 @@ def test_create_restart_from_pressure_against_fixture(tmp_path, matlab_fixture_d
         ('jdf3d_p12d_g981', 'p12d_g981'),
     )
 )
-def test_write_modified_control_against_fixture(tmp_path, matlab_fixture_dir, model_name, model_root):
+def test_write_modified_fehm_input_against_fixture(tmp_path, matlab_fixture_dir, model_name, model_root):
     model_dir = matlab_fixture_dir / model_name
     output_file = tmp_path / 'test.dat'
     file_extensions = {'perm', 'rock', 'cond', 'ppor', 'hflx', 'flow'}
 
-    write_modified_control_file(
+    write_modified_fehm_input_file(
         base_control_file=model_dir / f'{model_root}.dat',
         out_file=output_file,
         file_mapping={f'{model_root}.{ext}': f'test.{ext}' for ext in file_extensions},
@@ -206,11 +206,11 @@ def test_write_modified_control_against_fixture(tmp_path, matlab_fixture_dir, mo
         ('jdf3d_p12d_g981', 'p12d_g981'),
     )
 )
-def test_write_modified_control_with_timing_against_fixture(tmp_path, matlab_fixture_dir, model_name, model_root):
+def test_write_modified_fehm_input_with_timing_against_fixture(tmp_path, matlab_fixture_dir, model_name, model_root):
     model_dir = matlab_fixture_dir / model_name
     output_file = tmp_path / 'test.dat'
 
-    write_modified_control_file(
+    write_modified_fehm_input_file(
         base_control_file=model_dir / f'{model_root}.dat',
         out_file=output_file,
         initial_timestep_days=7300,


### PR DESCRIPTION
Add a function to replace `datcopy` and `datreset`, which reads an existing .dat file, modifies it where needed, and writes it back out. I've opted to use regex to search for the correct lines to replace, rather than searching line-by-line as done in Matlab.