### PR TITLE
End to end tests

### DIFF
--- a/.github/workflows/ci_pytest.yaml
+++ b/.github/workflows/ci_pytest.yaml
@@ -30,4 +30,4 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest
         run: |
-          pytest --ignore test/end_to_end
+          pytest

--- a/fehm_toolkit/config/hfi_reader.py
+++ b/fehm_toolkit/config/hfi_reader.py
@@ -25,6 +25,17 @@ def read_legacy_hfi_config(hfi_file: Path) -> dict:
             },
         }
 
+    constant = _get_constant_or_none(processed_text)
+    if constant is not None:
+        return {
+            'heatflux': {
+                'model_kind': 'constant_MW_per_m2',
+                'model_params': {
+                    'constant': constant,
+                }
+            }
+        }
+
     raise NotImplementedError(f'No model matched for {hfi_file}. File format not supported.')
 
 
@@ -88,3 +99,10 @@ def _read_and_process_hfi(hfi_file: Path) -> str:
         raise NotImplementedError(f'File ({hfi_file}) read no text, file format not supported.')
 
     return processed_text
+
+
+def _get_constant_or_none(processed_text: str) -> float:
+    match = re.search(fr'HFLX=@\(x,y,z\)({NUMERIC_PATTERN})(?:;|\n)', processed_text)
+    if match is None:
+        return None
+    return float(match.group(1))

--- a/fehm_toolkit/heat_in.py
+++ b/fehm_toolkit/heat_in.py
@@ -121,7 +121,10 @@ def _get_2d_axis_or_none(plot_data: pd.DataFrame) -> str:
 
 
 def get_heatflux_models_by_kind() -> dict[str, Callable]:
-    return {'crustal_age': _crustal_age_heatflux}
+    return {
+        'crustal_age': _crustal_age_heatflux,
+        'constant_MW_per_m2': _constant_MW_per_m2,
+    }
 
 
 def _crustal_age_heatflux(node: Node, params: dict) -> float:
@@ -130,6 +133,10 @@ def _crustal_age_heatflux(node: Node, params: dict) -> float:
     age_ma = 1 / (params['spread_rate_mm_per_year'] * 1E3) * distance_from_ridge_m
     heatflux_per_m2 = params['coefficient_MW'] / age_ma ** 0.5
     return -abs(node.outside_area.z * heatflux_per_m2)
+
+
+def _constant_MW_per_m2(node: Node, params: dict) -> float:
+    return -abs(node.outside_area.z * params['constant'])
 
 
 if __name__ == '__main__':

--- a/test/end_to_end/conftest.py
+++ b/test/end_to_end/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture
-def matlab_fixture_dir() -> Path:
-    return Path(__file__).parent.parent.parent / 'matlab_archive' / 'test' / 'fixtures'
+def end_to_end_fixture_dir() -> Path:
+    return Path(__file__).parent / 'fixtures'


### PR DESCRIPTION
This swaps over the end-to-end tests I had constructed to compare against Matlab versions to look at the new fixture grids instead. The benefit of this is that these run faster and are small enough for all users to download when cloning the repo - so running the tests is no longer something that you need special access or data for.