### PR TITLE
Create input file template

### DIFF
--- a/fehm_toolkit/fehm_runs/create_run_from_mesh.py
+++ b/fehm_toolkit/fehm_runs/create_run_from_mesh.py
@@ -83,11 +83,11 @@ def create_run_from_mesh(
     create_template_input_file(files_config, output_file=run_directory / files_config.input)
     logger.info(
         'Suggested next steps:\n'
-        f'Update {run_directory / CONFIG_NAME} with desired configuration'
-        '* Run heat_in to generate heat flux file'
-        '* Run rock_properties to generate physical properties files'
-        f'* Update {files_config.input} with desired configuration'
-        f'* Run FEHM'
+        f'Update {run_directory / CONFIG_NAME} with desired configuration\n'
+        '* Run heat_in to generate heat flux file\n'
+        '* Run rock_properties to generate physical properties files\n'
+        f'* Update {files_config.input} with desired configuration\n'
+        f'* Run FEHM\n'
     )
 
 

--- a/test/end_to_end/test_create_run_from_mesh.py
+++ b/test/end_to_end/test_create_run_from_mesh.py
@@ -1,5 +1,5 @@
 from fehm_toolkit.config import FilesConfig
-from fehm_toolkit.fehm_runs.create_run_from_mesh import create_run_from_mesh, create_files_index
+from fehm_toolkit.fehm_runs.create_run_from_mesh import create_run_from_mesh, create_template_input_file
 
 
 def test_create_run_from_mesh_flat_box_infer(tmp_path, end_to_end_fixture_dir):
@@ -19,6 +19,7 @@ def test_create_run_from_mesh_flat_box_infer(tmp_path, end_to_end_fixture_dir):
         'flat_box.stor',
         'flat_box.fehmn',
         'files.txt',
+        'input.txt',
     }
 
 
@@ -40,6 +41,7 @@ def test_create_run_from_mesh_flat_box_infer_run_root(tmp_path, end_to_end_fixtu
         'new_run.stor',
         'new_run.fehm',
         'new_run.files',
+        'new_run.dat',
     }
 
 
@@ -67,4 +69,46 @@ def test_create_run_from_mesh_outcrop_explicit_files(tmp_path, end_to_end_fixtur
         'new_run.stor',
         'new_run.fehm',
         'new_run.files',
+        'new_run.dat',
     }
+
+
+def test_create_template_input_file(tmp_path):
+    output_file = tmp_path / 'test.dat'
+    files_config = FilesConfig(
+        run_root='run_root',
+        material_zone='material_zone.txt',
+        outside_zone='outside_zone.txt',
+        area='area.txt',
+        rock_properties='rock_properties.txt',
+        conductivity='conductivity.txt',
+        pore_pressure='pore_pressure.txt',
+        permeability='permeability.txt',
+        heat_flux='heat_flux.txt',
+        flow='flow.txt',
+        files='files.txt',
+        grid='grid.txt',
+        input='input.txt',
+        output='output.txt',
+        store='store.txt',
+        history='history.txt',
+        water_properties='water_properties.txt',
+        check='check.txt',
+        error='error.txt',
+        final_conditions='final_conditions.txt',
+    )
+    create_template_input_file(files_config, output_file=output_file)
+    assert output_file.read_text() == (
+        '"Template conductive run - ALL COMMENTS MUST BE REPLACED with real config!"\n'
+        'init\n    # init config goes here (pres macro may be used instead)\n'
+        'sol\n    -1    -1\n'
+        'ctrl\n    # ctrl config goes here\n'
+        'time\n    # time config goes here\n'
+        'hflx\n    # hflx config for fixed temperature zones goes here\n'
+        f'hflx\nfile\n{files_config.heat_flux}\n'
+        f'rock\nfile\n{files_config.rock_properties}\n'
+        f'cond\nfile\n{files_config.conductivity}\n'
+        f'perm\nfile\n{files_config.permeability}\n'
+        f'ppor\nfile\n{files_config.pore_pressure}\n'
+        'stop\n'
+    )


### PR DESCRIPTION
Create a template input (.dat) file. I've only included the required macros in this, and in most cases I simply note that the user should fill them in. The benefit of doing this is that it provides a starting point, and it automatically fills in the correct file locations, as consistent with the file paths in the newly created `config.yaml`.

This is a component of `create_run_from_mesh`, which is meant to replace `mkfehmdir`'s creation of a conductive run from a mesh.