### PR TITLE
Relative config paths

### DIFF
--- a/fehm_toolkit/config/files_config.py
+++ b/fehm_toolkit/config/files_config.py
@@ -1,12 +1,12 @@
-from dataclasses import dataclass
+import dataclasses
 from pathlib import Path
 from typing import Optional
 
 
-@dataclass
+@dataclasses.dataclass
 class FilesConfig:
     """Files configuration defining paths for model run."""
-    run_root: Path
+    run_root: str
     material_zone: Path
     outside_zone: Path
     area: Path
@@ -34,3 +34,18 @@ class FilesConfig:
             k: Path(v) if k != 'run_root' and v is not None else v
             for k, v in dct.items()
         })
+
+    def validate(self):
+        self._assert_specified_paths_exist()
+
+    def _assert_specified_paths_exist(self):
+        does_not_exist = set()
+        for key, path in dataclasses.asdict(self).items():
+            if key == 'run_root':
+                continue
+            if path is not None and not path.exists():
+                does_not_exist.add(path)
+        if does_not_exist:
+            raise AssertionError(
+                f'FileConfig contains specified paths that do not exist: {[p.absolute() for p in does_not_exist]}'
+            )

--- a/fehm_toolkit/config/files_config.py
+++ b/fehm_toolkit/config/files_config.py
@@ -1,4 +1,5 @@
 import dataclasses
+import os
 from pathlib import Path
 from typing import Optional
 
@@ -33,6 +34,12 @@ class FilesConfig:
         return cls(**{
             k: Path(v) if k != 'run_root' and v is not None else v
             for k, v in dct.items()
+        })
+
+    def relative_to(self, base: Path):
+        return FilesConfig(**{
+            k: Path(os.path.relpath(v, start=base)) if k != 'run_root' and v is not None else v
+            for k, v in dataclasses.asdict(self).items()
         })
 
     def validate(self):

--- a/fehm_toolkit/utilities/create_run_config_for_legacy_directory.py
+++ b/fehm_toolkit/utilities/create_run_config_for_legacy_directory.py
@@ -71,6 +71,9 @@ def create_run_config_for_legacy_directory(
         heat_flux=heat_flux_file or _find_unique_match(directory, '*.hflx', allow_none=True),
         initial_conditions=initial_conditions_file or _find_unique_match(directory, '*.ini', allow_none=True),
     )
+    files_config.validate()
+    files_config = files_config.relative_to(directory)
+
     run_config = RunConfig(
         heat_flux_config=read_legacy_hfi_config(hfi_file),
         pressure_config=read_legacy_ipi_config(ipi_file),

--- a/test/end_to_end/test_create_run_config_for_legacy_directory.py
+++ b/test/end_to_end/test_create_run_config_for_legacy_directory.py
@@ -4,11 +4,12 @@ from fehm_toolkit.utilities.create_run_config_for_legacy_directory import create
 
 def test_create_run_config_for_legacy_directory_infer_some(tmp_path, end_to_end_fixture_dir):
     output_file = tmp_path / 'config.yaml'
+    run_directory = end_to_end_fixture_dir / 'flat_box' / 'p12'
     create_run_config_for_legacy_directory(
-        directory=end_to_end_fixture_dir / 'flat_box' / 'p12',
+        directory=run_directory,
         config_file=output_file,
-        input_file=end_to_end_fixture_dir / 'p12.dat',  # specified to avoid other test fixtures in folder
-        final_conditions_file=end_to_end_fixture_dir / 'p12.fin',  # specified to avoid other test fixtures in folder
-        water_properties_file=end_to_end_fixture_dir / '../../nist120-1800.out',
+        input_file=run_directory / 'p12.dat',  # specified to avoid other test fixtures in folder
+        final_conditions_file=run_directory / 'p12.fin',  # specified to avoid other test fixtures in folder
+        water_properties_file=run_directory / '../../nist120-1800.out',
     )
     RunConfig.from_yaml(output_file)  # no asserts needed, RunConfig loading ensures correct structure

--- a/test/fehm_runs/test_create_run_from_mesh.py
+++ b/test/fehm_runs/test_create_run_from_mesh.py
@@ -54,5 +54,8 @@ def test_build_template_from_run_config():
     template = build_template_from_type(RunConfig)
     assert template.keys() == {'files_config', 'heat_flux_config', 'rock_properties_config', 'pressure_config'}
     assert template['heat_flux_config'] == {'heat_flux_model': {'kind': 'replace__str', 'params': {}}}
-    for value in template['files_config'].values():
-        assert value in ('replace__Path', 'replace__Path|NoneType')
+    for key, value in template['files_config'].items():
+        if key == 'run_root':
+            assert value == 'replace__str'
+        else:
+            assert value in ('replace__Path', 'replace__Path|NoneType')


### PR DESCRIPTION
Validate that all paths specified exist before generating config file from legacy configs. Also update this to write paths relative to the final config file, rather than relative to the working directory when run.