### PR TITLE
Rename fehm_file to grid_file for consistency

### DIFF
--- a/fehm_toolkit/heat_in.py
+++ b/fehm_toolkit/heat_in.py
@@ -10,7 +10,6 @@ from scipy.spatial import Voronoi, voronoi_plot_2d
 from .config import HeatFluxConfig, RunConfig
 from .fehm_objects import Grid, Node
 from .file_interface import read_grid, write_compact_node_data
-from .file_interface.legacy_config import read_legacy_hfi_config
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +17,7 @@ logger = logging.getLogger(__name__)
 def generate_input_heatflux_file(
     *,
     config_file: Path,
-    fehm_file: Path,
+    grid_file: Path,
     outside_zone_file: Path,
     area_file: Path,
     output_file: Path,
@@ -28,7 +27,7 @@ def generate_input_heatflux_file(
     config = RunConfig.from_yaml(config_file)
 
     logger.info('Parsing grid into memory')
-    grid = read_grid(fehm_file, outside_zone_file=outside_zone_file, area_file=area_file, read_elements=False)
+    grid = read_grid(grid_file, outside_zone_file=outside_zone_file, area_file=area_file, read_elements=False)
 
     logger.info('Computing boundary heat flux')
     heatflux_by_node = compute_boundary_heatflux(grid, config.heat_flux_config)
@@ -143,7 +142,7 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO, format="%(asctime)s (%(levelname)s) %(message)s")
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('--fehm_file', type=Path, help='Path to main grid (.fehm) file.')
+    parser.add_argument('--grid_file', type=Path, help='Path to main grid (.fehm) file.')
     parser.add_argument('--outside_zone_file', type=Path, help='Path to boundary (_outside.zone) file.')
     parser.add_argument('--area_file', type=Path, help='Path to boundary area (.area) file.')
     parser.add_argument('--config_file', type=Path, help='Path to configuration (.yaml/.hfi) file.')
@@ -153,7 +152,7 @@ if __name__ == '__main__':
 
     generate_input_heatflux_file(
         config_file=args.config_file,
-        fehm_file=args.fehm_file,
+        grid_file=args.grid_file,
         outside_zone_file=args.outside_zone_file,
         area_file=args.area_file,
         output_file=args.output_file,

--- a/fehm_toolkit/hydrostatic_pressure.py
+++ b/fehm_toolkit/hydrostatic_pressure.py
@@ -20,7 +20,7 @@ RANDOM_SAMPLE_SEED = 12
 def generate_hydrostatic_pressure_file(
     *,
     config_file: Path,
-    fehm_file: Path,
+    grid_file: Path,
     material_zone_file: Path,
     outside_zone_file: Path,
     restart_file: Path,
@@ -35,7 +35,7 @@ def generate_hydrostatic_pressure_file(
 
     logger.info('Reading node data into memory')
     grid = read_grid(
-        fehm_file,
+        grid_file,
         material_zone_file=material_zone_file,
         outside_zone_file=outside_zone_file,
         read_elements=False,
@@ -382,7 +382,7 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--config_file', type=Path, help='Path to configuration (.yaml/.ipi) file.')
-    parser.add_argument('--fehm_file', type=Path, help='Path to main grid (.fehm) file.')
+    parser.add_argument('--grid_file', type=Path, help='Path to main grid (.fehm) file.')
     parser.add_argument('--material_zone_file', type=Path, help='Path to material (_material.zone) file.')
     parser.add_argument('--outside_zone_file', type=Path, help='Path to boundary (_outside.zone) file.')
     parser.add_argument('--restart_file', type=Path, help='Path to restart (.fin/.ini) file.')
@@ -392,7 +392,7 @@ if __name__ == '__main__':
 
     generate_hydrostatic_pressure_file(
         config_file=args.config_file,
-        fehm_file=args.fehm_file,
+        grid_file=args.grid_file,
         material_zone_file=args.material_zone_file,
         outside_zone_file=args.outside_zone_file,
         restart_file=args.restart_file,

--- a/fehm_toolkit/rock_properties.py
+++ b/fehm_toolkit/rock_properties.py
@@ -6,7 +6,6 @@ from typing import Iterable
 from .config import ModelConfig, RockPropertiesConfig, RunConfig
 from .fehm_objects import Node, Grid, Zone
 from .file_interface import read_grid, write_compact_node_data
-from .file_interface.legacy_config import read_legacy_rpi_config
 from .property_models import get_rock_property_model
 
 logger = logging.getLogger(__name__)
@@ -17,7 +16,7 @@ PROPERTY_KINDS = ('grain_density', 'specific_heat', 'porosity', 'conductivity', 
 def generate_rock_properties_files(
     *,
     config_file: Path,
-    fehm_file: Path,
+    grid_file: Path,
     outside_zone_file: Path,
     material_zone_file: Path,
     cond_output_file: Path,
@@ -30,7 +29,7 @@ def generate_rock_properties_files(
 
     logger.info('Parsing grid into memory')
     grid = read_grid(
-        fehm_file,
+        grid_file,
         outside_zone_file=outside_zone_file,
         material_zone_file=material_zone_file,
         read_elements=False,
@@ -131,7 +130,7 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO, format="%(asctime)s (%(levelname)s) %(message)s")
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('--fehm_file', type=Path, help='Path to main grid (.fehm) file.')
+    parser.add_argument('--grid_file', type=Path, help='Path to main grid (.fehm) file.')
     parser.add_argument('--outside_zone_file', type=Path, help='Path to boundary (_outside.zone) file.')
     parser.add_argument('--material_zone_file', type=Path, help='Path to material zone (_material.zone) file.')
     parser.add_argument('--config_file', type=Path, help='Path to configuration (.yaml/.hfi) file.')
@@ -143,7 +142,7 @@ if __name__ == '__main__':
 
     generate_rock_properties_files(
         config_file=args.config_file,
-        fehm_file=args.fehm_file,
+        grid_file=args.grid_file,
         outside_zone_file=args.outside_zone_file,
         material_zone_file=args.material_zone_file,
         cond_output_file=args.cond_output_file,

--- a/test/end_to_end/test_written_files.py
+++ b/test/end_to_end/test_written_files.py
@@ -21,7 +21,7 @@ def test_heat_in_against_fixture(tmp_path, end_to_end_fixture_dir, mesh_name):
 
     generate_input_heatflux_file(
         config_file=model_dir / 'config.yaml',
-        fehm_file=model_dir / 'cond.fehm',
+        grid_file=model_dir / 'cond.fehm',
         outside_zone_file=model_dir / 'cond_outside.zone',
         area_file=model_dir / 'cond.area',
         output_file=output_file,
@@ -37,7 +37,7 @@ def test_rock_properties_against_fixture(tmp_path, end_to_end_fixture_dir, mesh_
     model_dir = end_to_end_fixture_dir / mesh_name / 'cond'
     generate_rock_properties_files(
         config_file=model_dir / 'config.yaml',
-        fehm_file=model_dir / 'cond.fehm',
+        grid_file=model_dir / 'cond.fehm',
         outside_zone_file=model_dir / 'cond_outside.zone',
         material_zone_file=model_dir / 'cond_material.zone',
         cond_output_file=tmp_path / 'output.cond',
@@ -183,7 +183,7 @@ def test_generate_hydrostatic_pressure(tmp_path, end_to_end_fixture_dir, mesh_na
 
     generate_hydrostatic_pressure_file(
         config_file=model_dir / 'config.yaml',
-        fehm_file=model_dir / 'cond.fehm',
+        grid_file=model_dir / 'cond.fehm',
         material_zone_file=model_dir / 'cond_material.zone',
         outside_zone_file=model_dir / 'cond_outside.zone',
         restart_file=model_dir / 'cond.fin',


### PR DESCRIPTION
Most of the codebase uses `grid_file`, but utilities use `fehm_file` - this renames for consistency. I've also removed a few unnecessary imports.