### PR TITLE
Move preprocessors

### DIFF
--- a/fehm_toolkit/file_manipulation/__init__.py
+++ b/fehm_toolkit/file_manipulation/__init__.py
@@ -1,0 +1,3 @@
+from .append_zones import append_zones
+from .create_restart import create_restart_from_avs, create_restart_from_restart
+from .modify_fehm_input_file import write_modified_fehm_input_file

--- a/fehm_toolkit/preprocessors/__init__.py
+++ b/fehm_toolkit/preprocessors/__init__.py
@@ -1,0 +1,3 @@
+from .heat_in import generate_input_heatflux_file
+from .hydrostatic_pressure import generate_hydrostatic_pressure_file
+from .rock_properties import generate_rock_properties_files

--- a/fehm_toolkit/preprocessors/heat_in.py
+++ b/fehm_toolkit/preprocessors/heat_in.py
@@ -7,9 +7,9 @@ from matplotlib import cm, colors, pyplot as plt
 import pandas as pd
 from scipy.spatial import Voronoi, voronoi_plot_2d
 
-from .config import HeatFluxConfig, RunConfig
-from .fehm_objects import Grid, Node
-from .file_interface import read_grid, write_compact_node_data
+from fehm_toolkit.config import HeatFluxConfig, RunConfig
+from fehm_toolkit.fehm_objects import Grid, Node
+from fehm_toolkit.file_interface import read_grid, write_compact_node_data
 
 logger = logging.getLogger(__name__)
 

--- a/fehm_toolkit/preprocessors/hydrostatic_pressure.py
+++ b/fehm_toolkit/preprocessors/hydrostatic_pressure.py
@@ -6,9 +6,9 @@ from typing import Callable, Optional, Sequence
 import numpy as np
 from scipy.interpolate import LinearNDInterpolator, NearestNDInterpolator, RegularGridInterpolator
 
-from .config import ModelConfig, PressureConfig, RunConfig
-from .fehm_objects import Grid, State
-from .file_interface import read_grid, read_nist_lookup_table, read_restart, write_pressure
+from fehm_toolkit.config import ModelConfig, PressureConfig, RunConfig
+from fehm_toolkit.fehm_objects import Grid, State
+from fehm_toolkit.file_interface import read_grid, read_nist_lookup_table, read_restart, write_pressure
 
 logger = logging.getLogger(__name__)
 

--- a/fehm_toolkit/preprocessors/rock_properties.py
+++ b/fehm_toolkit/preprocessors/rock_properties.py
@@ -3,10 +3,10 @@ import logging
 from pathlib import Path
 from typing import Iterable
 
-from .config import ModelConfig, RockPropertiesConfig, RunConfig
-from .fehm_objects import Node, Grid, Zone
-from .file_interface import read_grid, write_compact_node_data
-from .property_models import get_rock_property_model
+from fehm_toolkit.config import ModelConfig, RockPropertiesConfig, RunConfig
+from fehm_toolkit.fehm_objects import Node, Grid, Zone
+from fehm_toolkit.file_interface import read_grid, write_compact_node_data
+from fehm_toolkit.property_models import get_rock_property_model
 
 logger = logging.getLogger(__name__)
 

--- a/test/end_to_end/test_written_files.py
+++ b/test/end_to_end/test_written_files.py
@@ -4,12 +4,17 @@ from numpy.testing import assert_array_almost_equal
 import pytest
 
 from fehm_toolkit.file_interface import read_pressure, write_restart, write_zones
-from fehm_toolkit.preprocessors.heat_in import generate_input_heatflux_file
-from fehm_toolkit.preprocessors.hydrostatic_pressure import generate_hydrostatic_pressure_file
-from fehm_toolkit.preprocessors.rock_properties import generate_rock_properties_files
-from fehm_toolkit.file_manipulation.append_zones import append_zones
-from fehm_toolkit.file_manipulation.create_restart import create_restart_from_avs, create_restart_from_restart
-from fehm_toolkit.file_manipulation.modify_fehm_input_file import write_modified_fehm_input_file
+from fehm_toolkit.preprocessors import (
+    generate_input_heatflux_file,
+    generate_hydrostatic_pressure_file,
+    generate_rock_properties_files,
+)
+from fehm_toolkit.file_manipulation import (
+    append_zones,
+    create_restart_from_avs,
+    create_restart_from_restart,
+    write_modified_fehm_input_file,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/test/end_to_end/test_written_files.py
+++ b/test/end_to_end/test_written_files.py
@@ -4,9 +4,9 @@ from numpy.testing import assert_array_almost_equal
 import pytest
 
 from fehm_toolkit.file_interface import read_pressure, write_restart, write_zones
-from fehm_toolkit.heat_in import generate_input_heatflux_file
-from fehm_toolkit.hydrostatic_pressure import generate_hydrostatic_pressure_file
-from fehm_toolkit.rock_properties import generate_rock_properties_files
+from fehm_toolkit.preprocessors.heat_in import generate_input_heatflux_file
+from fehm_toolkit.preprocessors.hydrostatic_pressure import generate_hydrostatic_pressure_file
+from fehm_toolkit.preprocessors.rock_properties import generate_rock_properties_files
 from fehm_toolkit.file_manipulation.append_zones import append_zones
 from fehm_toolkit.file_manipulation.create_restart import create_restart_from_avs, create_restart_from_restart
 from fehm_toolkit.file_manipulation.modify_fehm_input_file import write_modified_fehm_input_file

--- a/test/utilities/test_hydrostatic_pressure.py
+++ b/test/utilities/test_hydrostatic_pressure.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from fehm_toolkit.hydrostatic_pressure import build_z_column_around_reference
+from fehm_toolkit.preprocessors.hydrostatic_pressure import build_z_column_around_reference
 
 
 @pytest.mark.parametrize('reference_z, z_interval_m, z_targets, expected', (


### PR DESCRIPTION
Move all preprocessors into a subpackage to help with better organisation. Update package interfaces and clean up test imports.