### PR TITLE
Relative filesconfig

### DIFF
--- a/fehm_toolkit/config/files_config.py
+++ b/fehm_toolkit/config/files_config.py
@@ -30,10 +30,15 @@ class FilesConfig:
     initial_conditions: Optional[Path] = None
 
     @classmethod
-    def from_dict(cls, dct):
+    def from_dict(cls, dct: dict, files_relative_to: Optional[Path] = None):
+        if files_relative_to is None:
+            files_relative_to = Path.cwd()
+        if not files_relative_to.is_dir():
+            files_relative_to = files_relative_to.parent
+
         return cls(**{
-            k: Path(v) if k != 'run_root' and v is not None else v
-            for k, v in dct.items()
+            key: files_relative_to / file_name if key != 'run_root' and file_name is not None else file_name
+            for key, file_name in dct.items()
         })
 
     def relative_to(self, base: Path):

--- a/fehm_toolkit/fehm_runs/create_config_for_legacy_run.py
+++ b/fehm_toolkit/fehm_runs/create_config_for_legacy_run.py
@@ -73,7 +73,6 @@ def create_config_for_legacy_run(
         initial_conditions=initial_conditions_file or get_unique_file(directory, '*.ini', optional=True),
     )
     files_config.validate()
-    files_config = files_config.relative_to(directory)
 
     run_config = RunConfig(
         heat_flux_config=read_legacy_hfi_config(hfi_file),

--- a/fehm_toolkit/fehm_runs/create_run_from_mesh.py
+++ b/fehm_toolkit/fehm_runs/create_run_from_mesh.py
@@ -73,8 +73,8 @@ def create_run_from_mesh(
     create_template_run_config(template_files_config, output_file=run_directory / CONFIG_NAME)
 
     files_config = FilesConfig.from_dict(template_files_config)
-    write_files_index(files_config, output_file=run_directory / files_config.files)
-    create_template_input_file(files_config, output_file=run_directory / files_config.input)
+    write_files_index(files_config, output_file=run_directory / files_config.files.name)
+    create_template_input_file(files_config, output_file=run_directory / files_config.input.name)
     logger.info(
         'Suggested next steps:\n'
         f'Update {run_directory / CONFIG_NAME} with desired configuration\n'

--- a/test/config/test_config_objects.py
+++ b/test/config/test_config_objects.py
@@ -173,9 +173,9 @@ def test_run_config_writes_relative_files(tmp_path, config_dict):
 def test_files_config(files_config_dict):
     config = FilesConfig.from_dict(files_config_dict)
     assert config.run_root == 'run_root'
-    assert config.material_zone == Path('run_root.zone')
-    assert config.area == Path('run_root.area')
-    assert config.water_properties == Path('../../end_to_end/fixtures/nist120-1800.out')
+    assert config.material_zone == Path.cwd() / 'run_root.zone'
+    assert config.area == Path.cwd() / 'run_root.area'
+    assert config.water_properties == Path.cwd() / '../../end_to_end/fixtures/nist120-1800.out'
     for k, v in asdict(config).items():
         if k == 'run_root':
             assert isinstance(v, str)

--- a/test/end_to_end/test_create_config_for_legacy_run.py
+++ b/test/end_to_end/test_create_config_for_legacy_run.py
@@ -8,36 +8,38 @@ def test_create_config_for_legacy_run_flat_box(tmp_path, end_to_end_fixture_dir)
     run_directory = end_to_end_fixture_dir / 'flat_box' / 'p12'
     tmp_model_dir = tmp_path / 'root' / 'model' / 'run'
     shutil.copytree(run_directory, tmp_model_dir)
-    (tmp_model_dir / '../../nist120-1800.out').touch()
+    (tmp_model_dir.parent.parent / 'nist120-1800.out').touch()
 
-    fixture_file = run_directory / 'config.yaml'
     output_file = tmp_model_dir / 'config.yaml'
+    fixture_file = tmp_model_dir / 'fixture.yaml'
+    output_file.rename(fixture_file)
+
     create_config_for_legacy_run(
         directory=tmp_model_dir,
         config_file=output_file,
         input_file=tmp_model_dir / 'p12.dat',  # specified to avoid other test fixtures in folder
         final_conditions_file=tmp_model_dir / 'p12.fin',  # specified to avoid other test fixtures in folder
-        water_properties_file=tmp_model_dir / '../../nist120-1800.out',
+        water_properties_file=tmp_model_dir.parent.parent / 'nist120-1800.out',
     )
-    RunConfig.from_yaml(output_file)  # loading ensures correct structure
-    assert output_file.read_text() == fixture_file.read_text()
+    assert RunConfig.from_yaml(output_file) == RunConfig.from_yaml(fixture_file)
 
 
 def test_create_config_for_legacy_run_outcrop_2d(tmp_path, end_to_end_fixture_dir):
     run_directory = end_to_end_fixture_dir / 'outcrop_2d' / 'p13'
     tmp_model_dir = tmp_path / 'root' / 'model' / 'run'
     shutil.copytree(run_directory, tmp_model_dir)
-    (tmp_model_dir / '../../nist120-1800.out').touch()
+    (tmp_model_dir.parent.parent / 'nist120-1800.out').touch()
 
-    fixture_file = run_directory / 'config.yaml'
     output_file = tmp_model_dir / 'config.yaml'
+    fixture_file = tmp_model_dir / 'config.yaml'
+    output_file.rename(fixture_file)
+
     create_config_for_legacy_run(
         directory=tmp_model_dir,
         config_file=output_file,
         input_file=tmp_model_dir / 'p13.dat',  # specified to avoid other test fixtures in folder
         initial_conditions_file=tmp_model_dir / 'p13.ini',  # specified to avoid other test fixtures in folder
         final_conditions_file=tmp_model_dir / 'p13.fin',  # specified to avoid other test fixtures in folder
-        water_properties_file=tmp_model_dir / '../../nist120-1800.out',
+        water_properties_file=tmp_model_dir.parent.parent / 'nist120-1800.out',
     )
-    RunConfig.from_yaml(output_file)  # loading ensures correct structure
-    assert output_file.read_text() == fixture_file.read_text()
+    assert RunConfig.from_yaml(output_file) == RunConfig.from_yaml(fixture_file)

--- a/test/end_to_end/test_create_config_for_legacy_run.py
+++ b/test/end_to_end/test_create_config_for_legacy_run.py
@@ -1,34 +1,43 @@
+import shutil
+
 from fehm_toolkit.config import RunConfig
 from fehm_toolkit.fehm_runs.create_config_for_legacy_run import create_config_for_legacy_run
 
 
 def test_create_config_for_legacy_run_flat_box(tmp_path, end_to_end_fixture_dir):
     run_directory = end_to_end_fixture_dir / 'flat_box' / 'p12'
+    tmp_model_dir = tmp_path / 'root' / 'model' / 'run'
+    shutil.copytree(run_directory, tmp_model_dir)
+    (tmp_model_dir / '../../nist120-1800.out').touch()
 
     fixture_file = run_directory / 'config.yaml'
-    output_file = tmp_path / 'config.yaml'
+    output_file = tmp_model_dir / 'config.yaml'
     create_config_for_legacy_run(
-        directory=run_directory,
+        directory=tmp_model_dir,
         config_file=output_file,
-        input_file=run_directory / 'p12.dat',  # specified to avoid other test fixtures in folder
-        final_conditions_file=run_directory / 'p12.fin',  # specified to avoid other test fixtures in folder
-        water_properties_file=run_directory / '../../nist120-1800.out',
+        input_file=tmp_model_dir / 'p12.dat',  # specified to avoid other test fixtures in folder
+        final_conditions_file=tmp_model_dir / 'p12.fin',  # specified to avoid other test fixtures in folder
+        water_properties_file=tmp_model_dir / '../../nist120-1800.out',
     )
-    assert RunConfig.from_yaml(output_file) == RunConfig.from_yaml(fixture_file)
+    RunConfig.from_yaml(output_file)  # loading ensures correct structure
+    assert output_file.read_text() == fixture_file.read_text()
 
 
 def test_create_config_for_legacy_run_outcrop_2d(tmp_path, end_to_end_fixture_dir):
     run_directory = end_to_end_fixture_dir / 'outcrop_2d' / 'p13'
+    tmp_model_dir = tmp_path / 'root' / 'model' / 'run'
+    shutil.copytree(run_directory, tmp_model_dir)
+    (tmp_model_dir / '../../nist120-1800.out').touch()
 
     fixture_file = run_directory / 'config.yaml'
-    output_file = tmp_path / 'config.yaml'
+    output_file = tmp_model_dir / 'config.yaml'
     create_config_for_legacy_run(
-        directory=run_directory,
+        directory=tmp_model_dir,
         config_file=output_file,
-        input_file=run_directory / 'p13.dat',  # specified to avoid other test fixtures in folder
-        initial_conditions_file=run_directory / 'p13.ini',  # specified to avoid other test fixtures in folder
-        final_conditions_file=run_directory / 'p13.fin',  # specified to avoid other test fixtures in folder
-        water_properties_file=run_directory / '../../nist120-1800.out',
+        input_file=tmp_model_dir / 'p13.dat',  # specified to avoid other test fixtures in folder
+        initial_conditions_file=tmp_model_dir / 'p13.ini',  # specified to avoid other test fixtures in folder
+        final_conditions_file=tmp_model_dir / 'p13.fin',  # specified to avoid other test fixtures in folder
+        water_properties_file=tmp_model_dir / '../../nist120-1800.out',
     )
     RunConfig.from_yaml(output_file)  # loading ensures correct structure
-    assert RunConfig.from_yaml(output_file) == RunConfig.from_yaml(fixture_file)
+    assert output_file.read_text() == fixture_file.read_text()

--- a/test/end_to_end/test_written_files.py
+++ b/test/end_to_end/test_written_files.py
@@ -37,7 +37,7 @@ def test_heat_in_against_fixture(tmp_path, end_to_end_fixture_dir, mesh_name):
 
 
 @pytest.mark.parametrize('mesh_name', ('flat_box', 'outcrop_2d', 'warped_box'))
-def test_rock_properties_against_fixture(tmp_path, end_to_end_fixture_dir, mesh_name):
+def test_rock_properties_against_fixture(tmp_path: Path, end_to_end_fixture_dir: Path, mesh_name: str):
     logger.info(f'Generating rock properties files ({mesh_name}).')
     model_dir = end_to_end_fixture_dir / mesh_name / 'cond'
     generate_rock_properties_files(
@@ -59,7 +59,7 @@ def test_rock_properties_against_fixture(tmp_path, end_to_end_fixture_dir, mesh_
 
 
 @pytest.mark.parametrize('mesh_name', ('flat_box', 'outcrop_2d', 'warped_box'))
-def test_append_zones_against_fixture(tmp_path, end_to_end_fixture_dir, mesh_name):
+def test_append_zones_against_fixture(tmp_path: Path, end_to_end_fixture_dir: Path, mesh_name: str):
     model_dir = end_to_end_fixture_dir / mesh_name / 'cond'
     output_file = tmp_path / 'output.zone'
     combined_zones = append_zones(
@@ -77,7 +77,13 @@ def test_append_zones_against_fixture(tmp_path, end_to_end_fixture_dir, mesh_nam
     ('flat_box', 'p12', 11),
     ('outcrop_2d', 'p13', 2),
 ))
-def test_create_restart_from_avs_against_fixture(tmp_path, end_to_end_fixture_dir, mesh_name, model_name, avs_number):
+def test_create_restart_from_avs_against_fixture(
+    tmp_path: Path,
+    end_to_end_fixture_dir: Path,
+    mesh_name: str,
+    model_name: str,
+    avs_number: int,
+):
     model_dir = end_to_end_fixture_dir / mesh_name / model_name
     state, metadata = create_restart_from_avs(
         avs_file=model_dir / f'{model_name}.{avs_number:05d}_sca_node.avs',
@@ -99,7 +105,12 @@ def test_create_restart_from_avs_against_fixture(tmp_path, end_to_end_fixture_di
         ('warped_box', 'cond'),
     )
 )
-def test_create_restart_from_restart_against_fixture(tmp_path, end_to_end_fixture_dir, mesh_name, model_name):
+def test_create_restart_from_restart_against_fixture(
+    tmp_path: Path,
+    end_to_end_fixture_dir: Path,
+    mesh_name: str,
+    model_name: str,
+):
     model_dir = end_to_end_fixture_dir / mesh_name / model_name
     state, metadata = create_restart_from_restart(model_dir / f'{model_name}.fin', reset_model_time=True)
 
@@ -142,7 +153,12 @@ def test_create_restart_from_pressure_against_fixture(tmp_path, end_to_end_fixtu
         ('warped_box', 'cond'),
     )
 )
-def test_write_modified_fehm_input_against_fixture(tmp_path, end_to_end_fixture_dir, mesh_name, model_name):
+def test_write_modified_fehm_input_against_fixture(
+    tmp_path: Path,
+    end_to_end_fixture_dir: Path,
+    mesh_name: str,
+    model_name: str,
+):
     model_dir = end_to_end_fixture_dir / mesh_name / model_name
     output_file = tmp_path / 'test.dat'
     file_extensions = {'perm', 'rock', 'cond', 'ppor', 'hflx', 'flow'}
@@ -166,7 +182,12 @@ def test_write_modified_fehm_input_against_fixture(tmp_path, end_to_end_fixture_
         ('warped_box', 'cond'),
     )
 )
-def test_write_modified_fehm_input_with_timing_against_fixture(tmp_path, end_to_end_fixture_dir, mesh_name, model_name):
+def test_write_modified_fehm_input_with_timing_against_fixture(
+    tmp_path: Path,
+    end_to_end_fixture_dir: Path,
+    mesh_name: str,
+    model_name: str,
+):
     model_dir = end_to_end_fixture_dir / mesh_name / model_name
     output_file = tmp_path / 'test.dat'
 
@@ -182,7 +203,7 @@ def test_write_modified_fehm_input_with_timing_against_fixture(tmp_path, end_to_
 
 
 @pytest.mark.parametrize('mesh_name', ('flat_box', 'outcrop_2d', 'warped_box'))
-def test_generate_hydrostatic_pressure(tmp_path, end_to_end_fixture_dir, mesh_name):
+def test_generate_hydrostatic_pressure(tmp_path: Path, end_to_end_fixture_dir: Path, mesh_name: str):
     model_dir = end_to_end_fixture_dir / mesh_name / 'cond'
     output_file = tmp_path / 'test.iap'
 

--- a/test/end_to_end/test_written_files.py
+++ b/test/end_to_end/test_written_files.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 
 from numpy.testing import assert_array_almost_equal
 import pytest


### PR DESCRIPTION
Previously I updated the FilesConfig to be written such that the paths therin would be relative to the config.yaml location - but neglected to update the readers to handle this new state. This PR updates the config reader to parse the paths found as relative to the config file location, as intended.