### PR TITLE
Clean up utilities

### DIFF
--- a/fehm_toolkit/preprocessors/heat_in.py
+++ b/fehm_toolkit/preprocessors/heat_in.py
@@ -14,28 +14,27 @@ from fehm_toolkit.file_interface import read_grid, write_compact_node_data
 logger = logging.getLogger(__name__)
 
 
-def generate_input_heatflux_file(
-    *,
-    config_file: Path,
-    grid_file: Path,
-    outside_zone_file: Path,
-    area_file: Path,
-    output_file: Path,
-    plot_result: bool = False,
-):
+def generate_input_heatflux_file(config_file: Path, plot_result: bool = False):
     logger.info(f'Reading configuration file: {config_file}')
     config = RunConfig.from_yaml(config_file)
+    if not config.files_config.heat_flux:
+        raise ValueError(f'No heat_flux file defined in {config_file}, required for output.')
 
     logger.info('Parsing grid into memory')
-    grid = read_grid(grid_file, outside_zone_file=outside_zone_file, area_file=area_file, read_elements=False)
+    grid = read_grid(
+        config.files_config.grid,
+        outside_zone_file=config.files_config.outside_zone,
+        area_file=config.files_config.area,
+        read_elements=False,
+    )
 
     logger.info('Computing boundary heat flux')
     heatflux_by_node = compute_boundary_heatflux(grid, config.heat_flux_config)
 
-    logger.info(f'Writing heat flux to disk: {output_file}')
+    logger.info(f'Writing heat flux to disk: {config.files_config.heat_flux}')
     write_compact_node_data(
         heatflux_by_node,
-        output_file,
+        config.files_config.heat_flux,
         header='hflx\n',
         footer='0\n',
         style='heatflux',
@@ -142,19 +141,8 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO, format="%(asctime)s (%(levelname)s) %(message)s")
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('--grid_file', type=Path, help='Path to main grid (.fehm) file.')
-    parser.add_argument('--outside_zone_file', type=Path, help='Path to boundary (_outside.zone) file.')
-    parser.add_argument('--area_file', type=Path, help='Path to boundary area (.area) file.')
     parser.add_argument('--config_file', type=Path, help='Path to configuration (.yaml/.hfi) file.')
-    parser.add_argument('--output_file', type=Path, help='Path for heatflux output to be written.')
     parser.add_argument('--plot_result', action='store_true', help='Flag to optionally plot the heatflux.')
     args = parser.parse_args()
 
-    generate_input_heatflux_file(
-        config_file=args.config_file,
-        grid_file=args.grid_file,
-        outside_zone_file=args.outside_zone_file,
-        area_file=args.area_file,
-        output_file=args.output_file,
-        plot_result=args.plot_result,
-    )
+    generate_input_heatflux_file(args.config_file, plot_result=args.plot_result)

--- a/fehm_toolkit/preprocessors/heat_in.py
+++ b/fehm_toolkit/preprocessors/heat_in.py
@@ -141,7 +141,7 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO, format="%(asctime)s (%(levelname)s) %(message)s")
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('--config_file', type=Path, help='Path to configuration (.yaml/.hfi) file.')
+    parser.add_argument('config_file', type=Path, help='Path to configuration (.yaml/.hfi) file.')
     parser.add_argument('--plot_result', action='store_true', help='Flag to optionally plot the heatflux.')
     args = parser.parse_args()
 

--- a/test/end_to_end/test_written_files.py
+++ b/test/end_to_end/test_written_files.py
@@ -42,20 +42,17 @@ def test_heat_in_against_fixture(tmp_path: Path, end_to_end_fixture_dir: Path, m
 def test_rock_properties_against_fixture(tmp_path: Path, end_to_end_fixture_dir: Path, mesh_name: str):
     logger.info(f'Generating rock properties files ({mesh_name}).')
     model_dir = end_to_end_fixture_dir / mesh_name / 'cond'
-    generate_rock_properties_files(
-        config_file=model_dir / 'config.yaml',
-        grid_file=model_dir / 'cond.fehm',
-        outside_zone_file=model_dir / 'cond_outside.zone',
-        material_zone_file=model_dir / 'cond_material.zone',
-        cond_output_file=tmp_path / 'output.cond',
-        perm_output_file=tmp_path / 'output.perm',
-        ppor_output_file=tmp_path / 'output.ppor',
-        rock_output_file=tmp_path / 'output.rock',
-    )
+
+    tmp_model_dir = tmp_path / 'model_dir'
+    shutil.copytree(model_dir, tmp_model_dir)
+    for output_extension in ('cond', 'perm', 'ppor', 'rock'):
+        os.remove(tmp_model_dir / f'cond.{output_extension}')
+
+    generate_rock_properties_files(tmp_model_dir / 'config.yaml')
 
     for output_extension in ('cond', 'perm', 'ppor', 'rock'):
         logger.info(f'Comparing output for {output_extension} file.')
-        output_file = tmp_path / f'output.{output_extension}'
+        output_file = tmp_model_dir / f'cond.{output_extension}'
         fixture_file = model_dir / f'cond.{output_extension}'
         assert output_file.read_text() == fixture_file.read_text()
 

--- a/test/end_to_end/test_written_files.py
+++ b/test/end_to_end/test_written_files.py
@@ -1,9 +1,12 @@
 import logging
+import os
 from pathlib import Path
+import shutil
 
 from numpy.testing import assert_array_almost_equal
 import pytest
 
+from fehm_toolkit.config import RunConfig
 from fehm_toolkit.file_interface import read_pressure, write_restart, write_zones
 from fehm_toolkit.preprocessors import (
     generate_input_heatflux_file,
@@ -21,17 +24,15 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize('mesh_name', ('flat_box', 'outcrop_2d', 'warped_box'))
-def test_heat_in_against_fixture(tmp_path, end_to_end_fixture_dir, mesh_name):
+def test_heat_in_against_fixture(tmp_path: Path, end_to_end_fixture_dir: Path, mesh_name: str):
     model_dir = end_to_end_fixture_dir / mesh_name / 'cond'
-    output_file = tmp_path / 'output.hflx'
+    tmp_model_dir = tmp_path / 'model_dir'
 
-    generate_input_heatflux_file(
-        config_file=model_dir / 'config.yaml',
-        grid_file=model_dir / 'cond.fehm',
-        outside_zone_file=model_dir / 'cond_outside.zone',
-        area_file=model_dir / 'cond.area',
-        output_file=output_file,
-    )
+    shutil.copytree(model_dir, tmp_model_dir)
+    output_file = RunConfig.from_yaml(tmp_model_dir / 'config.yaml').files_config.heat_flux
+    os.remove(output_file)
+
+    generate_input_heatflux_file(tmp_model_dir / 'config.yaml')
 
     fixture_file = model_dir / 'cond.hflx'
     assert output_file.read_text() == fixture_file.read_text()

--- a/test/end_to_end/test_written_files.py
+++ b/test/end_to_end/test_written_files.py
@@ -209,15 +209,7 @@ def test_generate_hydrostatic_pressure(tmp_path: Path, end_to_end_fixture_dir: P
     model_dir = end_to_end_fixture_dir / mesh_name / 'cond'
     output_file = tmp_path / 'test.iap'
 
-    generate_hydrostatic_pressure_file(
-        config_file=model_dir / 'config.yaml',
-        grid_file=model_dir / 'cond.fehm',
-        material_zone_file=model_dir / 'cond_material.zone',
-        outside_zone_file=model_dir / 'cond_outside.zone',
-        restart_file=model_dir / 'cond.fin',
-        water_properties_file=end_to_end_fixture_dir / 'nist120-1800.out',
-        output_file=output_file,
-    )
+    generate_hydrostatic_pressure_file(model_dir / 'config.yaml', output_file=output_file)
     fixture_file = model_dir / 'cond.iap'
 
     fixture_pressure = read_pressure(fixture_file)


### PR DESCRIPTION
This PR removes command line arguments and function arguments for legacy configuration on `heat_in`, `hydrostatic_pressure`, and `rock_properties` utilities, now that we can generate the new configuration file for the legacy case. Tests have been updated to match.