### PR TITLE
Entry points

### DIFF
--- a/fehm_toolkit/command_line_interface.py
+++ b/fehm_toolkit/command_line_interface.py
@@ -1,0 +1,58 @@
+import argparse
+import logging
+from pathlib import Path
+
+from .fehm_runs import create_config_for_legacy_run, create_run_from_mesh
+
+
+def entry_point():
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s (%(levelname)s) %(message)s")
+
+    parser = argparse.ArgumentParser(prog='fehmtk', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    subparsers = parser.add_subparsers(help='FEHM toolkit commands')
+
+    create_run = subparsers.add_parser('create_run_from_mesh', help='Generate a new run directory from a LaGriT mesh')
+    create_run.add_argument('mesh_directory', type=Path, help='Path to mesh directory containing source files')
+    create_run.add_argument('run_directory', type=Path, help='Path to destination run directory to be created')
+    create_run.add_argument('water_properties_file', type=Path, help='Path to NIST lookup table (.out/.wpi)')
+    create_run.add_argument('--run_root', type=str, help='Common root to be used to name run files')
+    create_run.add_argument('--grid_file', type=Path, help='Path to main grid (.fehm[n]) file')
+    create_run.add_argument('--store_file', type=Path, help='Path to FEHM storage coefficients (.stor) file')
+    create_run.add_argument('--material_zone_file', type=Path, help='Path to material (_material.zone) file')
+    create_run.add_argument('--outside_zone_file', type=Path, help='Path to boundary (_outside.zone) file')
+    create_run.add_argument('--area_file', type=Path, help='Path to boundary area (.area) file')
+    create_run.set_defaults(func=create_run_from_mesh)
+
+    create_config = subparsers.add_parser(
+        'create_config_for_legacy_run',
+        help='Generate a config.yaml file from legacy configuration files (e.g. .hfi/.rpi/.ipi)',
+    )
+    create_config.add_argument('directory', type=Path, help='Path to directory with legacy configuration files')
+    create_config.add_argument('--hfi_file', type=Path, help='Legacy heat flux configuration file')
+    create_config.add_argument('--rpi_file', type=Path, help='Legacy rock properties configuration file')
+    create_config.add_argument('--ipi_file', type=Path, help='Legacy pressure configuration file')
+    create_config.add_argument('--material_zone_file', type=Path, help='Material_zone file')
+    create_config.add_argument('--outside_zone_file', type=Path, help='Outside_zone file')
+    create_config.add_argument('--area_file', type=Path, help='Area file')
+    create_config.add_argument('--rock_properties_file', type=Path, help='Rock_properties file')
+    create_config.add_argument('--conductivity_file', type=Path, help='Conductivity file')
+    create_config.add_argument('--pore_pressure_file', type=Path, help='Pore_pressure file')
+    create_config.add_argument('--permeability_file', type=Path, help='Permeability file')
+    create_config.add_argument('--files_file', type=Path, help='Files file')
+    create_config.add_argument('--grid_file', type=Path, help='Grid file')
+    create_config.add_argument('--input_file', type=Path, help='Input file')
+    create_config.add_argument('--output_file', type=Path, help='Output file')
+    create_config.add_argument('--store_file', type=Path, help='Store file')
+    create_config.add_argument('--history_file', type=Path, help='History file')
+    create_config.add_argument('--water_properties_file', type=Path, help='Water_properties file')
+    create_config.add_argument('--check_file', type=Path, help='Check file')
+    create_config.add_argument('--error_file', type=Path, help='Error file')
+    create_config.add_argument('--final_conditions_file', type=Path, help='Final_conditions file')
+    create_config.add_argument('--flow_file', type=Path, help='Flow file')
+    create_config.add_argument('--heat_flux_file', type=Path, help='Heat flux file')
+    create_config.add_argument('--initial_conditions_file', type=Path, help='Initial_conditions file')
+    create_config.set_defaults(func=create_config_for_legacy_run)
+
+    args = vars(parser.parse_args())
+    func = args.pop('func')
+    func(**args)

--- a/fehm_toolkit/fehm_runs/__init__.py
+++ b/fehm_toolkit/fehm_runs/__init__.py
@@ -1,0 +1,2 @@
+from .create_config_for_legacy_run import create_config_for_legacy_run
+from .create_run_from_mesh import create_run_from_mesh

--- a/fehm_toolkit/fehm_runs/create_config_for_legacy_run.py
+++ b/fehm_toolkit/fehm_runs/create_config_for_legacy_run.py
@@ -1,4 +1,3 @@
-import argparse
 import logging
 from pathlib import Path
 from typing import Optional
@@ -16,7 +15,6 @@ logger = logging.getLogger(__name__)
 
 def create_config_for_legacy_run(
     directory: Path,
-    config_file: Path,
     hfi_file: Optional[Path] = None,
     rpi_file: Optional[Path] = None,
     ipi_file: Optional[Path] = None,
@@ -80,8 +78,8 @@ def create_config_for_legacy_run(
         rock_properties_config=read_legacy_rpi_config(rpi_file),
         files_config=files_config,
     )
-    logger.info('Writing config file to %s', config_file)
-    run_config.to_yaml(config_file)
+    logger.info('Writing config file to %s', directory / 'config.yaml')
+    run_config.to_yaml(directory / 'config.yaml')
 
 
 def _find_material_zone_file(directory: Path) -> Path:
@@ -99,63 +97,3 @@ def _find_material_zone_file(directory: Path) -> Path:
         raise ValueError('Could not find unique material zone file.')
 
     return material_zone_file
-
-
-if __name__ == '__main__':
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s (%(levelname)s) %(message)s")
-
-    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('directory', type=Path, help='Path to directory with legacy configuration files.')
-    parser.add_argument('--config_file', type=Path, help='Output configuration file location (default: config.yaml).')
-    parser.add_argument('--hfi_file', type=Path, help='Optional location of legacy heat flux configuration file.')
-    parser.add_argument('--rpi_file', type=Path, help='Optional location of legacy rock properties configuration file.')
-    parser.add_argument('--ipi_file', type=Path, help='Optional location of legacy pressure configuration file.')
-    parser.add_argument('--material_zone_file', type=Path, help='Optional location of material_zone file.')
-    parser.add_argument('--outside_zone_file', type=Path, help='Optional location of outside_zone file.')
-    parser.add_argument('--area_file', type=Path, help='Optional location of area file.')
-    parser.add_argument('--rock_properties_file', type=Path, help='Optional location of rock_properties file.')
-    parser.add_argument('--conductivity_file', type=Path, help='Optional location of conductivity file.')
-    parser.add_argument('--pore_pressure_file', type=Path, help='Optional location of pore_pressure file.')
-    parser.add_argument('--permeability_file', type=Path, help='Optional location of permeability file.')
-    parser.add_argument('--files_file', type=Path, help='Optional location of files file.')
-    parser.add_argument('--grid_file', type=Path, help='Optional location of grid file.')
-    parser.add_argument('--input_file', type=Path, help='Optional location of input file.')
-    parser.add_argument('--output_file', type=Path, help='Optional location of output file.')
-    parser.add_argument('--store_file', type=Path, help='Optional location of store file.')
-    parser.add_argument('--history_file', type=Path, help='Optional location of history file.')
-    parser.add_argument('--water_properties_file', type=Path, help='Optional location of water_properties file.')
-    parser.add_argument('--check_file', type=Path, help='Optional location of check file.')
-    parser.add_argument('--error_file', type=Path, help='Optional location of error file.')
-    parser.add_argument('--final_conditions_file', type=Path, help='Optional location of final_conditions file.')
-    parser.add_argument('--flow_file', type=Path, help='Optional location of flow file.')
-    parser.add_argument('--heat_flux_file', type=Path, help='Optional location of heat_flux file.')
-    parser.add_argument('--initial_conditions_file', type=Path, help='Optional location of initial_conditions file.')
-    args = parser.parse_args()
-
-    create_config_for_legacy_run(
-        args.directory,
-        config_file=args.config_file or args.directory / 'config.yaml',
-        hfi_file=args.hfi_file,
-        rpi_file=args.rpi_file,
-        ipi_file=args.ipi_file,
-        material_zone_file=args.material_zone_file,
-        outside_zone_file=args.outside_zone_file,
-        area_file=args.area_file,
-        rock_properties_file=args.rock_properties_file,
-        conductivity_file=args.conductivity_file,
-        pore_pressure_file=args.pore_pressure_file,
-        permeability_file=args.permeability_file,
-        files_file=args.files_file,
-        grid_file=args.grid_file,
-        input_file=args.input_file,
-        output_file=args.output_file,
-        store_file=args.store_file,
-        history_file=args.history_file,
-        water_properties_file=args.water_properties_file,
-        check_file=args.check_file,
-        error_file=args.error_file,
-        final_conditions_file=args.final_conditions_file,
-        flow_file=args.flow_file,
-        heat_flux_file=args.heat_flux_file,
-        initial_conditions_file=args.initial_conditions_file,
-    )

--- a/fehm_toolkit/fehm_runs/create_run_from_mesh.py
+++ b/fehm_toolkit/fehm_runs/create_run_from_mesh.py
@@ -77,7 +77,7 @@ def create_run_from_mesh(
     create_template_input_file(files_config, output_file=run_directory / files_config.input.name)
     logger.info(
         'Suggested next steps:\n'
-        f'Update {run_directory / CONFIG_NAME} with desired configuration\n'
+        f'* Update {run_directory / CONFIG_NAME} with desired configuration\n'
         '* Run heat_in to generate heat flux file\n'
         '* Run rock_properties to generate physical properties files\n'
         f'* Update {files_config.input} with desired configuration\n'
@@ -212,31 +212,3 @@ def _get_template_files_config(
         template_files_config[field.name] = field_value
 
     return template_files_config
-
-
-if __name__ == '__main__':
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s (%(levelname)s) %(message)s')
-
-    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('mesh_directory', type=Path, help='Path to mesh directory containing source files.')
-    parser.add_argument('run_directory', type=Path, help='Path to destination run directory, to be created.')
-    parser.add_argument('water_properties_file', type=Path, help='Path to NIST lookup table (.out/.wpi).')
-    parser.add_argument('--run_root', type=str, help='Common root to be used to name run files.')
-    parser.add_argument('--grid_file', type=Path, help='Path to main grid [.fehm(n)] file.')
-    parser.add_argument('--store_file', type=Path, help='Path to FEHM storage coeffieicents (.stor) file.')
-    parser.add_argument('--material_zone_file', type=Path, help='Path to material (_material.zone) file.')
-    parser.add_argument('--outside_zone_file', type=Path, help='Path to boundary (_outside.zone) file.')
-    parser.add_argument('--area_file', type=Path, help='Path to boundary area (.area) file.')
-    args = parser.parse_args()
-
-    create_run_from_mesh(
-        mesh_directory=args.mesh_directory,
-        run_directory=args.run_directory,
-        water_properties_file=args.water_properties_file,
-        run_root=args.run_root,
-        grid_file=args.grid_file,
-        store_file=args.store_file,
-        material_zone_file=args.material_zone_file,
-        outside_zone_file=args.outside_zone_file,
-        area_file=args.area_file,
-    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,10 @@ test =
 all =
     %(test)s
 
+[options.entry_points]
+console_scripts =
+    fehmtk = fehm_toolkit.command_line_interface:entry_point
+
 [options.packages.find]
 exclude =
     test

--- a/test/end_to_end/test_create_config_for_legacy_run.py
+++ b/test/end_to_end/test_create_config_for_legacy_run.py
@@ -16,7 +16,6 @@ def test_create_config_for_legacy_run_flat_box(tmp_path, end_to_end_fixture_dir)
 
     create_config_for_legacy_run(
         directory=tmp_model_dir,
-        config_file=output_file,
         input_file=tmp_model_dir / 'p12.dat',  # specified to avoid other test fixtures in folder
         final_conditions_file=tmp_model_dir / 'p12.fin',  # specified to avoid other test fixtures in folder
         water_properties_file=tmp_model_dir.parent.parent / 'nist120-1800.out',
@@ -36,7 +35,6 @@ def test_create_config_for_legacy_run_outcrop_2d(tmp_path, end_to_end_fixture_di
 
     create_config_for_legacy_run(
         directory=tmp_model_dir,
-        config_file=output_file,
         input_file=tmp_model_dir / 'p13.dat',  # specified to avoid other test fixtures in folder
         initial_conditions_file=tmp_model_dir / 'p13.ini',  # specified to avoid other test fixtures in folder
         final_conditions_file=tmp_model_dir / 'p13.fin',  # specified to avoid other test fixtures in folder


### PR DESCRIPTION
This reworks the way commands are called from the command-line. Once set up, this change allows users to invoke the FEHM toolkit from anywhere directly from the terminal like:
```fehmtk create_config_for_legacy_run ../legacy/run/directory```

A list of commands is generated with ```fehmtk --help```, and details on arguments, etc. by calling help on the specific command, e.g. ```fehmtk create_run_from_mesh --help```.

Additional commands will be added for all other utilities in upcoming PRs, and can be extended easily in the future. All of this will be documented clearly and shared broadly with the team.