### PR TITLE
Preprocessor entry points

### DIFF
--- a/fehm_toolkit/fehm_runs/create_run_from_mesh.py
+++ b/fehm_toolkit/fehm_runs/create_run_from_mesh.py
@@ -1,4 +1,3 @@
-import argparse
 import dataclasses
 import logging
 from pathlib import Path

--- a/fehm_toolkit/preprocessors/__init__.py
+++ b/fehm_toolkit/preprocessors/__init__.py
@@ -1,3 +1,3 @@
-from .heat_in import generate_input_heatflux_file
-from .hydrostatic_pressure import generate_hydrostatic_pressure_file
-from .rock_properties import generate_rock_properties_files
+from .heat_in import generate_input_heat_flux
+from .hydrostatic_pressure import generate_hydrostatic_pressure
+from .rock_properties import generate_rock_properties

--- a/fehm_toolkit/preprocessors/heat_in.py
+++ b/fehm_toolkit/preprocessors/heat_in.py
@@ -1,4 +1,3 @@
-import argparse
 import logging
 from pathlib import Path
 from typing import Callable
@@ -14,7 +13,7 @@ from fehm_toolkit.file_interface import read_grid, write_compact_node_data
 logger = logging.getLogger(__name__)
 
 
-def generate_input_heatflux_file(config_file: Path, plot_result: bool = False):
+def generate_input_heat_flux(config_file: Path, plot_result: bool = False):
     logger.info(f'Reading configuration file: {config_file}')
     config = RunConfig.from_yaml(config_file)
     if not config.files_config.heat_flux:
@@ -135,14 +134,3 @@ def _crustal_age_heatflux(node: Node, params: dict) -> float:
 
 def _constant_MW_per_m2(node: Node, params: dict) -> float:
     return -abs(node.outside_area.z * params['constant'])
-
-
-if __name__ == '__main__':
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s (%(levelname)s) %(message)s")
-
-    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('config_file', type=Path, help='Path to configuration (.yaml/.hfi) file.')
-    parser.add_argument('--plot_result', action='store_true', help='Flag to optionally plot the heatflux.')
-    args = parser.parse_args()
-
-    generate_input_heatflux_file(args.config_file, plot_result=args.plot_result)

--- a/fehm_toolkit/preprocessors/hydrostatic_pressure.py
+++ b/fehm_toolkit/preprocessors/hydrostatic_pressure.py
@@ -1,4 +1,3 @@
-import argparse
 import logging
 from pathlib import Path
 from typing import Callable, Optional, Sequence
@@ -17,7 +16,7 @@ GRAVITY_ACCELERATION_M_S2 = -9.80665
 RANDOM_SAMPLE_SEED = 12
 
 
-def generate_hydrostatic_pressure_file(config_file: Path, output_file: Path):
+def generate_hydrostatic_pressure(config_file: Path, output_file: Path):
     logger.info(f'Reading configuration file: {config_file}')
     config = RunConfig.from_yaml(config_file)
 
@@ -366,14 +365,3 @@ def _validate_pressure_config(config: PressureConfig, node_coordinates: np.ndarr
                 f'Number of sample dimensions ({sample_xy_dimensions}) '
                 f'inconsistent with grid dimensions ({node_xy_dimensions}).'
             )
-
-
-if __name__ == '__main__':
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s (%(levelname)s) %(message)s')
-
-    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('config_file', type=Path, help='Path to configuration (.yaml) file.')
-    parser.add_argument('--output_file', type=Path, help='Path for pressure output (.iap) to be written.')
-    args = parser.parse_args()
-
-    generate_hydrostatic_pressure_file(args.config_file, output_file=args.output_file)

--- a/fehm_toolkit/preprocessors/rock_properties.py
+++ b/fehm_toolkit/preprocessors/rock_properties.py
@@ -1,4 +1,3 @@
-import argparse
 import logging
 from pathlib import Path
 from typing import Iterable
@@ -13,7 +12,7 @@ logger = logging.getLogger(__name__)
 PROPERTY_KINDS = ('grain_density', 'specific_heat', 'porosity', 'conductivity', 'permeability', 'compressibility')
 
 
-def generate_rock_properties_files(config_file: Path):
+def generate_rock_properties(config_file: Path):
     logger.info(f'Reading configuration file: {config_file}')
     config = RunConfig.from_yaml(config_file)
 
@@ -114,13 +113,3 @@ def _validate_all_nodes_covered(property_lookups: dict, n_nodes: int):
         missing_nodes = expected_nodes - values_by_node.keys()
         if missing_nodes:
             raise ValueError(f'Computed {property_kind} missing values for nodes: {missing_nodes}')
-
-
-if __name__ == '__main__':
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s (%(levelname)s) %(message)s")
-
-    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('config_file', type=Path, help='Path to configuration (.yaml) file.')
-    args = parser.parse_args()
-
-    generate_rock_properties_files(args.config_file)

--- a/test/end_to_end/test_written_files.py
+++ b/test/end_to_end/test_written_files.py
@@ -9,9 +9,9 @@ import pytest
 from fehm_toolkit.config import RunConfig
 from fehm_toolkit.file_interface import read_pressure, write_restart, write_zones
 from fehm_toolkit.preprocessors import (
-    generate_input_heatflux_file,
-    generate_hydrostatic_pressure_file,
-    generate_rock_properties_files,
+    generate_input_heat_flux,
+    generate_hydrostatic_pressure,
+    generate_rock_properties,
 )
 from fehm_toolkit.file_manipulation import (
     append_zones,
@@ -32,7 +32,7 @@ def test_heat_in_against_fixture(tmp_path: Path, end_to_end_fixture_dir: Path, m
     output_file = RunConfig.from_yaml(tmp_model_dir / 'config.yaml').files_config.heat_flux
     os.remove(output_file)
 
-    generate_input_heatflux_file(tmp_model_dir / 'config.yaml')
+    generate_input_heat_flux(tmp_model_dir / 'config.yaml')
 
     fixture_file = model_dir / 'cond.hflx'
     assert output_file.read_text() == fixture_file.read_text()
@@ -48,7 +48,7 @@ def test_rock_properties_against_fixture(tmp_path: Path, end_to_end_fixture_dir:
     for output_extension in ('cond', 'perm', 'ppor', 'rock'):
         os.remove(tmp_model_dir / f'cond.{output_extension}')
 
-    generate_rock_properties_files(tmp_model_dir / 'config.yaml')
+    generate_rock_properties(tmp_model_dir / 'config.yaml')
 
     for output_extension in ('cond', 'perm', 'ppor', 'rock'):
         logger.info(f'Comparing output for {output_extension} file.')
@@ -206,7 +206,7 @@ def test_generate_hydrostatic_pressure(tmp_path: Path, end_to_end_fixture_dir: P
     model_dir = end_to_end_fixture_dir / mesh_name / 'cond'
     output_file = tmp_path / 'test.iap'
 
-    generate_hydrostatic_pressure_file(model_dir / 'config.yaml', output_file=output_file)
+    generate_hydrostatic_pressure(model_dir / 'config.yaml', output_file=output_file)
     fixture_file = model_dir / 'cond.iap'
 
     fixture_pressure = read_pressure(fixture_file)


### PR DESCRIPTION
Incorporate preprocessors into entry points (`generate_hydrostatic_pressure`, `generate_input_heat_flux`, and `generate_rock_properties`). This allows them to be called via `fehmtk` at the command line.