### PR TITLE
Restart format

### DIFF
--- a/fehm_toolkit/file_interface/restart.py
+++ b/fehm_toolkit/file_interface/restart.py
@@ -62,7 +62,7 @@ def _parse_scalar_block(open_file: TextIO, n_nodes: int) -> list[Decimal]:
     return scalar_values
 
 
-def write_restart(state: State, metadata: RestartMetadata, output_file: Path, fmt: str = 'legacy'):
+def write_restart(state: State, metadata: RestartMetadata, output_file: Path, fmt: str = 'fehm'):
     state.validate()
     if metadata.unsupported_blocks:
         raise NotImplementedError('Some blocks in restart not supported, cannot guarantee accurate write.')

--- a/test/end_to_end/test_written_files.py
+++ b/test/end_to_end/test_written_files.py
@@ -91,7 +91,7 @@ def test_create_restart_from_avs_against_fixture(
     output_file = tmp_path / 'test.fin'
     fixture_file = model_dir / 'avs2fin.fin_fixture'
 
-    write_restart(state, metadata, output_file=output_file)
+    write_restart(state, metadata, output_file=output_file, fmt='legacy')
 
     assert output_file.read_text() == fixture_file.read_text()
 
@@ -116,7 +116,7 @@ def test_create_restart_from_restart_against_fixture(
     output_file = tmp_path / 'test.fin'
     fixture_file = model_dir / 'fin2ini.ini_fixture'
 
-    write_restart(state, metadata, output_file=output_file)
+    write_restart(state, metadata, output_file=output_file, fmt='legacy')
 
     assert output_file.read_text() == fixture_file.read_text()
 
@@ -138,7 +138,7 @@ def test_create_restart_from_pressure_against_fixture(tmp_path, end_to_end_fixtu
     output_file = tmp_path / 'test.ini'
     fixture_file = model_dir / 'iap2ini.ini_fixture'
 
-    write_restart(state, metadata, output_file=output_file)
+    write_restart(state, metadata, output_file=output_file, fmt='legacy')
 
     assert output_file.read_text() == fixture_file.read_text()
 

--- a/test/file_interface/test_writeback.py
+++ b/test/file_interface/test_writeback.py
@@ -38,7 +38,7 @@ def test_writeback_restart_legacy_format(fixture_dir, tmp_path):
     output_file = tmp_path / 'out.restart'
 
     state, metadata = read_restart(initial_file)
-    write_restart(state, metadata, output_file)
+    write_restart(state, metadata, output_file, fmt='legacy')
 
     assert initial_file.read_text() == output_file.read_text()
 
@@ -57,7 +57,7 @@ def test_tracer_restart_raises(fixture_dir, tmp_path):
     state, metadata = read_restart(fixture_dir / 'tracer_restart.fin')
 
     with pytest.raises(NotImplementedError):
-        write_restart(state, metadata, tmp_path / 'out.restart')
+        write_restart(state, metadata, tmp_path / 'out.restart', fmt='legacy')
 
 
 def test_writeback_pressure(fixture_dir, tmp_path):


### PR DESCRIPTION
Change default format for restart files (.ini/.fin) to be in "fehm" style - which matches that generated by LaGriT and FEHM. I had previously set this to legacy to match Matlab output during testing, but there is no longer a good reason to persist this format.