### PR TITLE
Refactor run from mesh

### DIFF
--- a/fehm_toolkit/command_line_interface.py
+++ b/fehm_toolkit/command_line_interface.py
@@ -19,7 +19,7 @@ def entry_point():
 
     create_run = subparsers.add_parser('create_run_from_mesh', help='Create a new run directory from a LaGriT mesh')
     create_run.add_argument('mesh_directory', type=Path, help='Mesh directory containing source files')
-    create_run.add_argument('run_directory', type=Path, help='Destination run directory to be created')
+    create_run.add_argument('target_directory', type=Path, help='Destination run directory to be created')
     create_run.add_argument('water_properties_file', type=Path, help='NIST lookup table (.out/.wpi)')
     create_run.add_argument(
         '--append_outside_zones',

--- a/fehm_toolkit/file_manipulation/__init__.py
+++ b/fehm_toolkit/file_manipulation/__init__.py
@@ -1,3 +1,4 @@
 from .append_zones import append_zones
 from .create_restart import create_restart_from_avs, create_restart_from_restart
+from .directories import create_run_with_source_files
 from .modify_fehm_input_file import write_modified_fehm_input_file

--- a/fehm_toolkit/file_manipulation/directories.py
+++ b/fehm_toolkit/file_manipulation/directories.py
@@ -1,0 +1,23 @@
+import logging
+from pathlib import Path
+import shutil
+
+
+logger = logging.getLogger(__name__)
+
+
+def create_run_with_source_files(target_directory: Path, file_pairs_by_file_type: dict[str, tuple[Path, Path]]):
+    logger.info('Creating directory %s', target_directory)
+    target_directory.mkdir()
+
+    file_pairs_by_file_type = file_pairs_by_file_type.copy()
+    (source_water_properties_file, run_water_properties_file) = file_pairs_by_file_type.pop('water_properties')
+    if source_water_properties_file.is_symlink():
+        source_water_properties_file = source_water_properties_file.readlink()
+
+    logger.info('Linking %s -> %s', run_water_properties_file, source_water_properties_file)
+    run_water_properties_file.symlink_to(source_water_properties_file)
+
+    for k, (source_file, run_file) in file_pairs_by_file_type.items():
+        logger.info('Copying %s to %s', source_file, run_file)
+        shutil.copy(source_file, run_file)

--- a/test/end_to_end/test_create_run_from_mesh.py
+++ b/test/end_to_end/test_create_run_from_mesh.py
@@ -6,7 +6,7 @@ def test_create_run_from_mesh_flat_box_infer(tmp_path, end_to_end_fixture_dir):
     new_directory = tmp_path / 'new_run'
     create_run_from_mesh(
         mesh_directory=end_to_end_fixture_dir / 'flat_box' / 'mesh',
-        run_directory=new_directory,
+        target_directory=new_directory,
         water_properties_file=end_to_end_fixture_dir / 'nist120-1800.out',
     )
     new_files = {path.name for path in new_directory.iterdir()}
@@ -27,7 +27,7 @@ def test_create_run_from_mesh_flat_box_infer_run_root(tmp_path, end_to_end_fixtu
     new_directory = tmp_path / 'new_run'
     create_run_from_mesh(
         mesh_directory=end_to_end_fixture_dir / 'flat_box' / 'mesh',
-        run_directory=new_directory,
+        target_directory=new_directory,
         water_properties_file=end_to_end_fixture_dir / 'nist120-1800.out',
         run_root='new_run',
     )
@@ -50,7 +50,7 @@ def test_create_run_from_mesh_outcrop_explicit_files(tmp_path, end_to_end_fixtur
     new_directory = tmp_path / 'new_run'
     create_run_from_mesh(
         mesh_directory=mesh_directory,
-        run_directory=new_directory,
+        target_directory=new_directory,
         water_properties_file=end_to_end_fixture_dir / 'nist120-1800.out',
         run_root='new_run',
         grid_file=mesh_directory / 'outcrop_2d.fehmn',

--- a/test/end_to_end/test_create_runs.py
+++ b/test/end_to_end/test_create_runs.py
@@ -1,5 +1,6 @@
 from fehm_toolkit.config import FilesConfig
-from fehm_toolkit.fehm_runs.create_run_from_mesh import create_run_from_mesh, create_template_input_file
+from fehm_toolkit.fehm_runs import create_run_from_mesh
+from fehm_toolkit.fehm_runs.create_run_from_mesh import create_template_input_file
 
 
 def test_create_run_from_mesh_flat_box_infer(tmp_path, end_to_end_fixture_dir):


### PR DESCRIPTION
This factors out code for creating new directories from `create_run_from_mesh`, so that it can be used in the upcoming `create_run_from_run` as well. I've also included some iteration on argument naming in this PR.