### PR TITLE
Implement create run from run

### DIFF
--- a/fehm_toolkit/fehm_runs/__init__.py
+++ b/fehm_toolkit/fehm_runs/__init__.py
@@ -1,2 +1,3 @@
 from .create_config_for_legacy_run import create_config_for_legacy_run
 from .create_run_from_mesh import create_run_from_mesh
+from .create_run_from_run import create_run_from_run

--- a/test/end_to_end/test_create_runs.py
+++ b/test/end_to_end/test_create_runs.py
@@ -1,6 +1,7 @@
-from fehm_toolkit.config import FilesConfig
-from fehm_toolkit.fehm_runs import create_run_from_mesh
+from fehm_toolkit.config import FilesConfig, RunConfig
+from fehm_toolkit.fehm_runs import create_run_from_mesh, create_run_from_run
 from fehm_toolkit.fehm_runs.create_run_from_mesh import create_template_input_file
+from fehm_toolkit.file_interface import read_restart
 
 
 def test_create_run_from_mesh_flat_box_infer(tmp_path, end_to_end_fixture_dir):
@@ -113,3 +114,36 @@ def test_create_template_input_file(tmp_path):
         f'ppor\nfile\n{files_config.pore_pressure}\n'
         'stop\n'
     )
+
+
+def test_create_run_from_run(tmp_path, end_to_end_fixture_dir):
+    run_directory = end_to_end_fixture_dir / 'outcrop_2d' / 'cond'
+    run_config_file = run_directory / 'config.yaml'
+    new_directory = tmp_path / 'new_run'
+    new_config_file = new_directory / 'config.yaml'
+
+    create_run_from_run(run_config_file, new_directory)
+
+    run_config = RunConfig.from_yaml(run_config_file)
+    new_config = RunConfig.from_yaml(new_config_file)
+
+    assert new_config.files_config.material_zone.exists()
+    assert new_config.files_config.outside_zone.exists()
+    assert new_config.files_config.area.exists()
+    assert new_config.files_config.rock_properties.exists()
+    assert new_config.files_config.conductivity.exists()
+    assert new_config.files_config.pore_pressure.exists()
+    assert new_config.files_config.permeability.exists()
+    assert new_config.files_config.water_properties.exists() and new_config.files_config.water_properties.is_symlink()
+    assert new_config.files_config.grid.exists()
+    assert new_config.files_config.store.exists()
+    assert new_config.files_config.files.exists()
+    assert new_config.files_config.input.exists()
+
+    assert new_config.files_config.grid.read_text() == run_config.files_config.grid.read_text()
+    assert new_config.files_config.outside_zone.read_text() == run_config.files_config.outside_zone.read_text()
+    assert new_config.files_config.area.read_text() == run_config.files_config.area.read_text()
+    assert new_config.files_config.rock_properties.read_text() == run_config.files_config.rock_properties.read_text()
+    new_initial_state, _ = read_restart(new_config.files_config.initial_conditions)
+    run_final_state, _ = read_restart(run_config.files_config.final_conditions)
+    assert new_initial_state == run_final_state

--- a/test/fehm_objects/test_state.py
+++ b/test/fehm_objects/test_state.py
@@ -1,0 +1,42 @@
+import pytest
+
+from fehm_toolkit.fehm_objects import State
+from fehm_toolkit.fehm_runs.create_run_from_run import replace_node_pressures
+
+
+@pytest.fixture
+def simple_state():
+    return State(
+        temperature=(1, 2, 3, 4, 5),
+        pressure=(1, 2, 3, 4, 5),
+    )
+
+
+def test_replace_node_pressures(simple_state):
+    state = replace_node_pressures(
+        simple_state,
+        replacement_state=State(pressure=(8, 8, 8, 8, 8), temperature=(9, 9, 9, 9, 9)),
+        node_numbers=(1, 3, 5),
+    )
+    assert state == State(
+        pressure=(8, 2, 8, 4, 8),
+        temperature=(1, 2, 3, 4, 5),
+    )
+
+
+def test_replace_node_pressures_out_of_range(simple_state):
+    with pytest.raises(ValueError):
+        replace_node_pressures(
+            simple_state,
+            replacement_state=State(pressure=(8, 8, 8, 8, 8), temperature=(9, 9, 9, 9, 9)),
+            node_numbers=(1, 3, 18),
+        )
+
+
+def test_replace_node_pressures_different_sizes(simple_state):
+    with pytest.raises(ValueError):
+        replace_node_pressures(
+            simple_state,
+            replacement_state=State(pressure=(7, 8, 9), temperature=(7, 8, 9)),
+            node_numbers=(1, 2),
+        )


### PR DESCRIPTION
This creates library code for generating a new run directory from an existing one, performing all necessary pressure resets and file copying. This currently only supports the use-case where you are creating a run from a _completed_ model run. I plan to introduce a separate command to handle making new runs from _interrupted_ runs.