### PR TITLE
Simplify command names

### DIFF
--- a/fehm_toolkit/command_line_interface.py
+++ b/fehm_toolkit/command_line_interface.py
@@ -65,8 +65,8 @@ def entry_point():
     ))
 
     create_config = subparsers.add_parser(
-        'create_config_for_legacy_run',
-        help='Create config.yaml file from legacy configuration files (e.g. .hfi/.rpi/.ipi)',
+        'legacy_config',
+        help='Create config.yaml from legacy configuration files (e.g. .hfi/.rpi/.ipi)',
     )
     create_config.add_argument('directory', type=Path, help='Directory with legacy configuration files')
     create_config.add_argument('--hfi_file', type=Path, help='Legacy heat flux configuration file')
@@ -94,24 +94,18 @@ def entry_point():
     create_config.add_argument('--initial_conditions_file', type=Path, help='Initial_conditions file')
     create_config.set_defaults(func=create_config_for_legacy_run)
 
-    rock_properties = subparsers.add_parser(
-        'generate_rock_properties',
-        help='Generate rock properties for run based on configuration'
-    )
+    rock_properties = subparsers.add_parser('rock_properties', help='Generate rock properties from configuration')
     rock_properties.add_argument('config_file', type=Path, help='Run configuration (config.yaml) file')
     rock_properties.set_defaults(func=generate_rock_properties)
 
-    heat_in = subparsers.add_parser(
-        'generate_input_heat_flux',
-        help='Generate input heat flux based on run configuration'
-    )
+    heat_in = subparsers.add_parser('heat_in', help='Generate input heat flux based on run configuration')
     heat_in.add_argument('config_file', type=Path, help='Run configuration (.yaml/.hfi) file')
-    heat_in.add_argument('--plot_result', action='store_true', help='Flag to plot the heat flux')
+    heat_in.add_argument('--plot', action='store_true', help='Flag to plot the heat flux')
     heat_in.set_defaults(func=generate_input_heat_flux)
 
     pressure = subparsers.add_parser(
-        'generate_hydrostatic_pressure',
-        help='Generate hydrostatic pressures for run by bootstrapping down the column',
+        'hydrostat',
+        help='Generate hydrostatic pressures by interpolating and bootstrapping down the water column',
     )
     pressure.add_argument('config_file', type=Path, help='Run configuration (config.yaml) file')
     pressure.add_argument('output_file', type=Path, help='Pressure output (.iap/.icp) to be written')

--- a/fehm_toolkit/command_line_interface.py
+++ b/fehm_toolkit/command_line_interface.py
@@ -44,7 +44,7 @@ def entry_point():
     run_from_mesh.set_defaults(func=create_run_from_mesh)
 
     run_from_run = subparsers.add_parser(
-        'create_run_from_run',
+        'run_from_run',
         help='Create a run directory from a previous run',
         description=(
             'Create a run directory by copying files from an existing run. Model time is reset to 0. '
@@ -56,12 +56,12 @@ def entry_point():
     run_from_run.add_argument('target_directory', type=Path, help='Destination run directory to be created')
     run_from_run.add_argument('--run_root', type=str, help='Common root to be used to name run files')
     run_from_run_exclusive = run_from_run.add_mutually_exclusive_group()
-    run_from_run_exclusive.add_argument('--reset_initial_pressure_outside_zones', type=int_or_string, nargs='+', help=(
-        'Space-separated list of zone names or numbers; pressure in target initial conditions are reset to '
-        ' initial_conditions (per config_file), for nodes in specified zones'
+    run_from_run_exclusive.add_argument('--reset_zones', type=int_or_string, nargs='+', help=(
+        'Space-separated list of zone names or numbers referring to OUTSIDE zones; pressures set to '
+        ' initial_conditions for nodes in specified zones'
     ))
-    run_from_run_exclusive.add_argument('--override_pressure_file', type=Path, help=(
-        'Pressure (.iap/.icp) file; pressure in target initial conditions are set to these, for all nodes'
+    run_from_run_exclusive.add_argument('--pressure_file', type=Path, help=(
+        'Pressure (.iap/.icp) file; pressure set to those in file for all nodes'
     ))
 
     create_config = subparsers.add_parser(

--- a/fehm_toolkit/command_line_interface.py
+++ b/fehm_toolkit/command_line_interface.py
@@ -121,11 +121,9 @@ def entry_point():
         'append_zones',
         help='Append zones from one zone file to another, overwriting the target',
     )
-    zones.add_argument('add_zones_from_file', type=Path, help='Source file for new zones to add')
-    zones.add_argument('add_zones_to_file', type=Path, help='Target file that new zones will be added to')
-    zones.add_argument(
-        'zone_keys_to_add', type=int_or_string, nargs='+', help='Space-separated list of zone names or numbers',
-    )
+    zones.add_argument('source_file', type=Path, help='Source file for new zones to add')
+    zones.add_argument('target_file', type=Path, help='Target file that new zones will be added to')
+    zones.add_argument('zones', type=int_or_string, nargs='+', help='Space-separated list of zone names or numbers')
     zones.set_defaults(func=append_zones)
 
     args = vars(parser.parse_args())

--- a/fehm_toolkit/command_line_interface.py
+++ b/fehm_toolkit/command_line_interface.py
@@ -18,7 +18,7 @@ def entry_point():
     subparsers = parser.add_subparsers(help='FEHM toolkit commands')
 
     run_from_mesh = subparsers.add_parser(
-        'create_run_from_mesh',
+        'run_from_mesh',
         help='Create a new run directory from a LaGriT mesh',
         description=(
             'Create a run directory by copying files from a mesh direcotry. File name roots are replaced '
@@ -29,7 +29,7 @@ def entry_point():
     run_from_mesh.add_argument('target_directory', type=Path, help='Destination run directory to be created')
     run_from_mesh.add_argument('water_properties_file', type=Path, help='NIST lookup table (.out/.wpi)')
     run_from_mesh.add_argument(
-        '--append_outside_zones',
+        '--append_zones',
         type=int_or_string,
         nargs='+',
         help='Outside zones to append to material zone file',

--- a/fehm_toolkit/fehm_runs/create_run_from_mesh.py
+++ b/fehm_toolkit/fehm_runs/create_run_from_mesh.py
@@ -7,7 +7,7 @@ import yaml
 
 from fehm_toolkit.config import FilesConfig, RunConfig
 from fehm_toolkit.file_interface import get_unique_file, write_files_index
-from fehm_toolkit.file_manipulation import append_zones, create_run_with_source_files
+from fehm_toolkit import file_manipulation
 
 
 logger = logging.getLogger(__name__)
@@ -41,7 +41,7 @@ def create_run_from_mesh(
     mesh_directory: Path,
     target_directory: Path,
     water_properties_file: Path,
-    append_outside_zones: Optional[Sequence[str]] = ('top', 'bottom'),
+    append_zones: Optional[Sequence[str]] = ('top', 'bottom'),
     run_root: Optional[str] = None,
     grid_file: Optional[Path] = None,
     store_file: Optional[Path] = None,
@@ -68,12 +68,12 @@ def create_run_from_mesh(
         area_file=area_file or get_unique_file(mesh_directory, f"*{EXT_BY_FILE['area']}"),
         water_properties_file=water_properties_file,
     )
-    create_run_with_source_files(target_directory, file_pairs_by_file_type)
-    if append_outside_zones:
-        append_zones(
-            add_zones_from_file=file_pairs_by_file_type['outside_zone'][1],
-            add_zones_to_file=file_pairs_by_file_type['material_zone'][1],
-            zone_keys_to_add=append_outside_zones,
+    file_manipulation.create_run_with_source_files(target_directory, file_pairs_by_file_type)
+    if append_zones:
+        file_manipulation.append_zones(
+            source_file=file_pairs_by_file_type['outside_zone'][1],
+            target_file=file_pairs_by_file_type['material_zone'][1],
+            zones=append_zones,
         )
 
     template_files_config = _get_template_files_config(file_pairs_by_file_type, run_root)

--- a/fehm_toolkit/file_manipulation/append_zones.py
+++ b/fehm_toolkit/file_manipulation/append_zones.py
@@ -8,19 +8,15 @@ from ..file_interface import read_zones, write_zones
 logger = logging.getLogger(__name__)
 
 
-def append_zones(
-    add_zones_from_file: Path,
-    add_zones_to_file: Path,
-    zone_keys_to_add: Sequence[Union[int, str]],
-):
-    zones_to_add = _filter_zones_to_add(zone_keys_to_add, raw_zones_to_add=read_zones(add_zones_from_file))
+def append_zones(source_file: Path, target_file: Path, zones: Sequence[Union[int, str]]):
+    zones_to_add = _filter_zones_to_add(zones, raw_zones_to_add=read_zones(source_file))
     if not zones_to_add:
-        raise ValueError(f'No zones with keys {zone_keys_to_add} found in {add_zones_from_file}')
+        raise ValueError(f'No zones with keys {zones} found in {source_file}')
 
-    combined_zones = _combine_zones(zones_to_add=zones_to_add, source_zones=read_zones(add_zones_to_file))
+    combined_zones = _combine_zones(zones_to_add=zones_to_add, source_zones=read_zones(target_file))
 
-    logger.info('Writing zones %s from %s to %s', zone_keys_to_add, add_zones_from_file, add_zones_to_file)
-    write_zones(combined_zones, add_zones_to_file)
+    logger.info('Writing zones %s from %s to %s', zones, source_file, target_file)
+    write_zones(combined_zones, target_file)
 
 
 def _filter_zones_to_add(zone_keys_to_add: Sequence[Union[int, str]], raw_zones_to_add: tuple[Zone]) -> tuple[Zone]:

--- a/fehm_toolkit/preprocessors/heat_in.py
+++ b/fehm_toolkit/preprocessors/heat_in.py
@@ -13,7 +13,7 @@ from fehm_toolkit.file_interface import read_grid, write_compact_node_data
 logger = logging.getLogger(__name__)
 
 
-def generate_input_heat_flux(config_file: Path, plot_result: bool = False):
+def generate_input_heat_flux(config_file: Path, plot: bool = False):
     logger.info(f'Reading configuration file: {config_file}')
     config = RunConfig.from_yaml(config_file)
     if not config.files_config.heat_flux:
@@ -38,7 +38,7 @@ def generate_input_heat_flux(config_file: Path, plot_result: bool = False):
         footer='0\n',
         style='heatflux',
     )
-    if plot_result:
+    if plot:
         plot_heatflux(heatflux_by_node, grid)
 
 

--- a/test/end_to_end/test_create_runs.py
+++ b/test/end_to_end/test_create_runs.py
@@ -53,6 +53,7 @@ def test_create_run_from_mesh_outcrop_explicit_files(tmp_path, end_to_end_fixtur
     create_run_from_mesh(
         mesh_directory=mesh_directory,
         target_directory=new_directory,
+        append_zones=['top'],
         water_properties_file=end_to_end_fixture_dir / 'nist120-1800.out',
         run_root='new_run',
         grid_file=mesh_directory / 'outcrop_2d.fehmn',

--- a/test/end_to_end/test_written_files.py
+++ b/test/end_to_end/test_written_files.py
@@ -63,11 +63,7 @@ def test_append_zones_against_fixture(tmp_path: Path, end_to_end_fixture_dir: Pa
     output_file = tmp_path / 'output.zone'
     shutil.copy(model_dir / 'cond_material.zone', output_file)
 
-    append_zones(
-        add_zones_from_file=model_dir / 'cond_outside.zone',
-        add_zones_to_file=output_file,
-        zone_keys_to_add=('top', 'bottom'),
-    )
+    append_zones(source_file=model_dir / 'cond_outside.zone', target_file=output_file, zones=('top', 'bottom'))
     fixture_file = model_dir / 'cond.zone'
     assert output_file.read_text() == fixture_file.read_text()
 


### PR DESCRIPTION
This PR aims to reduce the length of command names and their arguments in the command line interface, where possible. This could be taken farther, but I'd like to start here and see how people like it.

Changes to argument names have been reflected in the code as well, it is currently simpler to keep these in sync with eachother, rather than maintain the mapping between the argument names at command line vs in code.