### PR TITLE
Swap all instances of power law and exponential

### DIFF
--- a/fehm_toolkit/file_interface/legacy_config/rpi_reader.py
+++ b/fehm_toolkit/file_interface/legacy_config/rpi_reader.py
@@ -136,12 +136,12 @@ def _get_models() -> tuple[tuple[str, str, Callable]]:
             'parser': _parse_params__assigned_constant,
         },
         {
-            'model_kind': 'depth_exponential_with_maximum',
+            'model_kind': 'depth_power_law_with_maximum',
             'signature': r'FUN=@\(depth\)min\(PORA\.\*depth\.\^\(PORB\),PORA\.\*50\.\^\(PORB\)\)(?:;|\n)',
             'parser': _parse_params__sediment_porosity,
         },
         {
-            'model_kind': 'depth_power_law',
+            'model_kind': 'depth_exponential',
             'signature': r'FUN=@\(depth\)PORA\.\*exp\(PORB\.\*depth\);',
             'parser': _parse_params__sediment_porosity,
         },
@@ -156,9 +156,9 @@ def _get_models() -> tuple[tuple[str, str, Callable]]:
             'parser': _parse_params__porosity_weighted,
         },
         {
-            'model_kind': 'void_ratio_power_law',
+            'model_kind': 'void_ratio_exponential',
             'signature': r'FUN=@\(depth,porosity\)A\.\*exp\(B\.\*VOID\(porosity\)\)(?:;|\n)',
-            'parser': _parse_params__void_ratio_power_law,
+            'parser': _parse_params__void_ratio_exponential,
         },
         {
             'model_kind': 'overburden',
@@ -226,7 +226,7 @@ def _parse_params__porosity_weighted(block: str) -> dict:
     return {'water_conductivity': float(match_kw.group(1)), 'rock_conductivity': float(match_k_grain.group(1))}
 
 
-def _parse_params__void_ratio_power_law(block: str) -> dict:
+def _parse_params__void_ratio_exponential(block: str) -> dict:
     match_a = re.search(rf'A=({NUMERIC_PATTERN})(?:;|\n)', block)
     match_b = re.search(rf'B=({NUMERIC_PATTERN})(?:;|\n)', block)
     if not match_a or not match_b:

--- a/fehm_toolkit/property_models/permeability.py
+++ b/fehm_toolkit/property_models/permeability.py
@@ -7,11 +7,11 @@ from .porosity import get_porosity_model
 
 def get_permeability_models_by_kind() -> dict:
     return {
-        'void_ratio_power_law': _void_ratio_power_law,
+        'void_ratio_exponential': _void_ratio_exponential,
     }
 
 
-def _void_ratio_power_law(
+def _void_ratio_exponential(
     depth: float,
     model_config_by_property_kind: dict[str, ModelConfig],
     property_kind: str,

--- a/fehm_toolkit/property_models/porosity.py
+++ b/fehm_toolkit/property_models/porosity.py
@@ -16,18 +16,18 @@ def get_porosity_model(model_kind: str) -> Callable:
 
 def get_porosity_models_by_kind() -> dict:
     return {
-        'depth_power_law': _depth_power_law,
-        'depth_exponential_with_maximum': _depth_exponential_with_maximum,
+        'depth_exponential': _depth_exponential,
+        'depth_power_law_with_maximum': _depth_power_law_with_maximum,
     }
 
 
-def _depth_power_law(depth: float, model_config_by_property_kind: dict[str, ModelConfig], property_kind: str) -> float:
+def _depth_exponential(depth: float, model_config_by_property_kind: dict[str, ModelConfig], property_kind: str) -> float:
     params = model_config_by_property_kind[property_kind].params
     porosity_a, porosity_b = params['porosity_a'], params['porosity_b']
     return porosity_a * math.exp(porosity_b * depth)
 
 
-def _depth_exponential_with_maximum(
+def _depth_power_law_with_maximum(
     depth: float,
     model_config_by_property_kind: dict[str, ModelConfig],
     property_kind: str,

--- a/test/config/fixtures/flat_box_cond.yaml
+++ b/test/config/fixtures/flat_box_cond.yaml
@@ -87,7 +87,7 @@ rock_properties_config:
     - 4
   permeability_configs:
   - property_model:
-      kind: void_ratio_power_law
+      kind: void_ratio_exponential
       params:
         A: 3.66e-18
         B: 1.68
@@ -108,7 +108,7 @@ rock_properties_config:
     - 4
   porosity_configs:
   - property_model:
-      kind: depth_exponential_with_maximum
+      kind: depth_exponential
       params:
         porosity_a: 0.84
         porosity_b: -0.125

--- a/test/config/fixtures/flat_box_config.yaml
+++ b/test/config/fixtures/flat_box_config.yaml
@@ -70,7 +70,7 @@ rock_properties_config:
 
   permeability_configs:
     - property_model:
-        kind: void_ratio_power_law
+        kind: void_ratio_exponential
         params:
           A: 3.66e-18
           B: 1.68
@@ -102,7 +102,7 @@ rock_properties_config:
 
   porosity_configs:
     - property_model:
-        kind: depth_power_law
+        kind: depth_exponential
         params:
           porosity_a: 0.84
           porosity_b: -0.125

--- a/test/config/test_config_objects.py
+++ b/test/config/test_config_objects.py
@@ -128,7 +128,7 @@ def rock_properties_config_dict():
         'porosity_configs': [
             {
                 'property_model': {
-                    'kind': 'depth_power_law',
+                    'kind': 'depth_exponential',
                     'params': {'porosity_a': 0.84, 'porosity_b': -0.125},
                 },
                 'zones': [1],

--- a/test/config/test_legacy_readers.py
+++ b/test/config/test_legacy_readers.py
@@ -75,7 +75,7 @@ def test_read_legacy_rpi_config_jdf(fixture_dir):
     assert config.permeability_configs == [
         PropertyConfig(
             property_model=ModelConfig(
-                kind='void_ratio_power_law',
+                kind='void_ratio_exponential',
                 params={'A': 3.66E-18, 'B': 1.68},
             ),
             zones=[1],

--- a/test/end_to_end/fixtures/flat_box/cond/config.yaml
+++ b/test/end_to_end/fixtures/flat_box/cond/config.yaml
@@ -98,7 +98,7 @@ rock_properties_config:
     - 3
   permeability_configs:
   - property_model:
-      kind: void_ratio_power_law
+      kind: void_ratio_exponential
       params:
         A: 3.66e-18
         B: 1.68
@@ -118,7 +118,7 @@ rock_properties_config:
     - 3
   porosity_configs:
   - property_model:
-      kind: depth_exponential_with_maximum
+      kind: depth_power_law_with_maximum
       params:
         porosity_a: 0.84
         porosity_b: -0.125

--- a/test/end_to_end/fixtures/flat_box/p12/config.yaml
+++ b/test/end_to_end/fixtures/flat_box/p12/config.yaml
@@ -100,7 +100,7 @@ rock_properties_config:
     - 3
   permeability_configs:
   - property_model:
-      kind: void_ratio_power_law
+      kind: void_ratio_exponential
       params:
         A: 3.66e-18
         B: 1.68
@@ -120,7 +120,7 @@ rock_properties_config:
     - 3
   porosity_configs:
   - property_model:
-      kind: depth_exponential_with_maximum
+      kind: depth_power_law_with_maximum
       params:
         porosity_a: 0.84
         porosity_b: -0.125

--- a/test/end_to_end/fixtures/outcrop_2d/cond/config.yaml
+++ b/test/end_to_end/fixtures/outcrop_2d/cond/config.yaml
@@ -87,7 +87,7 @@ rock_properties_config:
     - 4
   permeability_configs:
   - property_model:
-      kind: void_ratio_power_law
+      kind: void_ratio_exponential
       params:
         A: 3.66e-18
         B: 1.68
@@ -108,7 +108,7 @@ rock_properties_config:
     - 4
   porosity_configs:
   - property_model:
-      kind: depth_exponential_with_maximum
+      kind: depth_power_law_with_maximum
       params:
         porosity_a: 0.84
         porosity_b: -0.125

--- a/test/end_to_end/fixtures/outcrop_2d/p13/config.yaml
+++ b/test/end_to_end/fixtures/outcrop_2d/p13/config.yaml
@@ -89,7 +89,7 @@ rock_properties_config:
     - 4
   permeability_configs:
   - property_model:
-      kind: void_ratio_power_law
+      kind: void_ratio_exponential
       params:
         A: 3.66e-18
         B: 1.68
@@ -110,7 +110,7 @@ rock_properties_config:
     - 4
   porosity_configs:
   - property_model:
-      kind: depth_exponential_with_maximum
+      kind: depth_power_law_with_maximum
       params:
         porosity_a: 0.84
         porosity_b: -0.125


### PR DESCRIPTION
I had been incorrectly referring to exponentials and power laws in the names of property models, this PR reverses them such than now:
`A * exp(x)` is referred to as an exponential function, and
`A * x^B` is referred to as a power law.