### PR TITLE
Documentation for property models

### DIFF
--- a/fehm_toolkit/property_models/compressibility.py
+++ b/fehm_toolkit/property_models/compressibility.py
@@ -14,6 +14,16 @@ def get_compressibility_models_by_kind() -> dict:
 
 
 def _overburden(depth: float, model_config_by_property_kind: dict[str, ModelConfig], property_kind: str) -> float:
+    """Compressibility as a function of depth based on an overburden calculation:
+    0.435 * A * (1 - p) / b
+    where A is a constant and overburden b is calculated as described below. Porosity p is calculated separately with
+    its own property model.
+
+    Overburden b is calculated by summing up a column at a 1 meter interval as:
+    G * sum(g * (1 - p) + W * p - W) or B, whichever is higher
+    where G, W, and B are constants; G is the acceleration of gravity, W is the density of water, and B is the minimum
+    allowed overburden. Grain density g is calculated separately with its own property model.
+    """
     params = model_config_by_property_kind[property_kind].params
     porosity_model = get_porosity_model(model_config_by_property_kind['porosity'].kind)
     grain_density_model = get_generic_model(  # no grain_density-specific models exist at time of writing, using generic

--- a/fehm_toolkit/property_models/conductivity.py
+++ b/fehm_toolkit/property_models/conductivity.py
@@ -22,6 +22,11 @@ def _porosity_weighted(
     model_config_by_property_kind: dict[str, ModelConfig],
     property_kind: str,
 ) -> Vector:
+    """Combined conductivity of water and rock, weighted by porosity:
+    W^p * R^(1 - p)
+    where W and R are constants: water conductivity and rock conductivity, respectively. Porosity p is calculated
+    separately with its own property model.
+    """
     params = model_config_by_property_kind[property_kind].params
     kw, kg = params['water_conductivity'], params['rock_conductivity']
 
@@ -33,6 +38,15 @@ def _porosity_weighted(
 
 
 def _ctr2tcon(depth: float, model_config_by_property_kind: dict[str, ModelConfig], property_kind: str) -> Vector:
+    """Conductivity calculated by inverting a cumulative thermal resistance profile.
+
+    CTR must be defined with a ctr_model (e.g. polynomial function), and is optimised on the basis of the node depths
+    provided. For example, depth arrays of [[0, 50, 100], [0, 80]] will optimize the conductivity for two separate
+    columns (one with nodes at 0, 50, and 100, one with nodes at 0, 80).
+
+    This function is DEPRECATED, and has been included for backwards compatibility. It is recommended to specify
+    conductivity explicitly instead, performing any necessary calculations separately.
+    """
     params = model_config_by_property_kind[property_kind].params
 
     tcon_func = _get_tcon_func(params['ctr_model'])

--- a/fehm_toolkit/property_models/generic.py
+++ b/fehm_toolkit/property_models/generic.py
@@ -19,6 +19,8 @@ def _constant(
     model_config_by_property_kind: dict[str, ModelConfig],
     property_kind: str,
 ) -> Union[float, Vector]:
+    """Property set as a constant value. If the property is Vector valued, it is also isotropic.
+    """
     params = model_config_by_property_kind[property_kind].params
     constant = params['constant']
 

--- a/fehm_toolkit/property_models/permeability.py
+++ b/fehm_toolkit/property_models/permeability.py
@@ -16,6 +16,11 @@ def _void_ratio_exponential(
     model_config_by_property_kind: dict[str, ModelConfig],
     property_kind: str,
 ) -> Vector:
+    """Permeability following an exponential function of void ratio:
+    A * e^(B * v)
+    where A and B are constants, and v is the void ratio (p / (1 - p)). Porosity p is calculated separately with its
+    own property model.
+    """
     params = model_config_by_property_kind[property_kind].params
 
     porosity_model = get_porosity_model(model_config_by_property_kind['porosity'].kind)

--- a/fehm_toolkit/property_models/porosity.py
+++ b/fehm_toolkit/property_models/porosity.py
@@ -22,6 +22,10 @@ def get_porosity_models_by_kind() -> dict:
 
 
 def _depth_exponential(depth: float, model_config_by_property_kind: dict[str, ModelConfig], property_kind: str) -> float:
+    """Porosity following an exponential function of depth:
+    A * e^(B * d)
+    where A and B are constants, and d is depth below the seafloor.
+    """
     params = model_config_by_property_kind[property_kind].params
     porosity_a, porosity_b = params['porosity_a'], params['porosity_b']
     return porosity_a * math.exp(porosity_b * depth)
@@ -32,6 +36,10 @@ def _depth_power_law_with_maximum(
     model_config_by_property_kind: dict[str, ModelConfig],
     property_kind: str,
 ) -> float:
+    """Porosity following a power-law relationship of depth, with a maximum porosity applied:
+    A * d^B or A * 50^B, whichever is lower
+    where A and B are constants, and d is depth below the seafloor.
+    """
     params = model_config_by_property_kind[property_kind].params
     porosity_a, porosity_b = params['porosity_a'], params['porosity_b']
 


### PR DESCRIPTION
All of the property models used in the `rock_properties` routine had thus far not been documented. This corrects that by adding simple descriptions on each.