### PR TITLE
Remove analysis folder from language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+analysis/** linguist-vendored


### PR DESCRIPTION
Jupyter notebooks are very long, and tend to mess up GitHub's language stats to make the repository look more "Jupyter" than it actually is. This should configure to ignore the analysis folder, where notebook will primarily live.