### PR TITLE
Document installation and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,47 @@
 # FEHM Toolkit
-This toolkit consists of utilities and convenience functions to enable fast and efficient use of [FEHM](https://github.com/lanl/FEHM) and [LaGriT](https://github.com/lanl/LaGriT), which are software packages created by Los Alamos National Labs for simulations of coupled fluid-heat-solute transport and related processes. The specific focus of the FEHM Toolkit is on simulations of seafloor hydrothermal circulation.   
+This toolkit consists of utilities and convenience functions to enable fast and efficient use of [FEHM](https://github.com/lanl/FEHM) and [LaGriT](https://github.com/lanl/LaGriT), which are software packages created by Los Alamos National Labs for simulations of coupled fluid-heat-solute transport and related processes.
+
+The specific focus of the FEHM Toolkit is on simulations of seafloor hydrothermal circulation, though it can be used
+in other contexts and even modified to better support other use-cases as the need arises.
 
 ## Work in progress
-This toolkit is in the early stages of development and is not yet in working order. This page will be updated when an initial release is ready. Work to date is focused on collating and testing previous Matlab versions of the code.
+* This toolkit is in the early stages of development and is not yet in working order.
+* Work to date is focused on collating and testing previous Matlab versions of the code.
+* This page will be updated when an initial release is ready.
 
 ## Installation and use
-We currently only support "development" installations (see section below for instructions).
+We recommend installing as an editable package for both development and use of the toolkit.
 
-TODO(dustin): update with documentation for using the toolkit in non-dev mode.
+1. Install a system for managing virual environments. [Anaconda](https://www.anaconda.com/products/distribution#Downloads) or the lighter-weight [Miniconda](https://docs.conda.io/en/latest/miniconda.html#latest-miniconda-installer-links) are recommended, but you can use whatever you prefer.
+1. Create a new virtual environment (unless you want to install into an existing one):
 
-### Heat input
-To run the utility for generating heat input (`.hflx`) files, first activate a virtual environment with `fehm_toolkit` installed, then run:
-```bash
-python -m python -m fehm_toolkit.heat_in --help
-```
-This will show you the additional parameters you need to specify, for example:
-```bash
-python -m fehm_toolkit.heat_in --config_file p12.hfi --fehm_file p12.fehm --area_file p12.area --outside_zone_file p12_outside.zone --output_file test.hflx
-```
+    ```zsh
+    conda create -n fehmtk python=3.9
+    ```
 
-## Development
-The toolkit and its dependencies can be installed for development purposes. Simply clone the repository, then run the following commands:
+1. Clone the repository to your local code directory (`~/code` in this case):
 
-**Important** we strongly recommend installing this into a virtual environment (TODO: provide a link or tutorial explaining how to do this).
+    ```zsh
+    cd ~/code
+    git clone git@github.com:UCSC-Hydrogeology/fehmToolkit.git
+    ```
 
-```bash
-pip install -e ".[all]"
-```
-After this, run the tests to check everything is running correctly:
-```bash
-pytest
-```
+1. Install the toolkit into your environment:
+
+    ```zsh
+    conda activate fehmtk
+    cd fehmToolkit
+    pip install -e ".[all]"
+    ```
+
+1. Run the tests to check everything is set up correctly:
+
+    ```zsh
+    pytest
+    ```
+
+1. Start using the toolkit:
+
+    ```zsh
+    fehmtk --help
+    ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # FEHM Toolkit
 This toolkit consists of utilities and convenience functions to enable fast and efficient use of [FEHM](https://github.com/lanl/FEHM) and [LaGriT](https://github.com/lanl/LaGriT), which are software packages created by Los Alamos National Labs for simulations of coupled fluid-heat-solute transport and related processes.
 
-The specific focus of the FEHM Toolkit is on simulations of seafloor hydrothermal circulation, though it can be used
-in other contexts and even modified to better support other use-cases as the need arises.
+The specific focus of the FEHM Toolkit is on simulations of seafloor hydrothermal circulation, though it can be used in other contexts and even modified to better support other use-cases as the need arises.
 
 ## Work in progress
 * This toolkit is in the early stages of development and is not yet in working order.


### PR DESCRIPTION
This updates documentation to include installation instructions and the commands needed to get started with basic usage. Will add something sepatately describing the `config.yaml` file, as well as a more verbose tutorial - but basic instructions here will get people started.