### PR TITLE
Fix mesh files template

### DIFF
--- a/fehm_toolkit/fehm_runs/create_run_from_mesh.py
+++ b/fehm_toolkit/fehm_runs/create_run_from_mesh.py
@@ -87,8 +87,8 @@ def create_run_from_mesh(
         f'* Update {target_directory / CONFIG_NAME} with desired configuration\n'
         '* Run heat_in to generate heat flux file\n'
         '* Run rock_properties to generate physical properties files\n'
-        f'* Update {files_config.input} with desired configuration\n'
-        f'* Run FEHM\n'
+        f'* Update {target_directory / files_config.input.name} with desired configuration\n'
+        f'* Run FEHM'
     )
 
 
@@ -132,7 +132,7 @@ def _get_type_name(base_type: Type):
 
 
 def create_template_input_file(files_config: FilesConfig, output_file: Path):
-    logger.info(f'Writing template input file to {output_file}. This file is incomplete and must be modified!')
+    logger.info(f'Writing template input file to {output_file}')
     with open(output_file, 'w') as f:
         f.write('"Template conductive run - ALL COMMENTS MUST BE REPLACED with real config!"\n')
         f.write('init\n    # init config goes here (pres macro may be used instead)\n')

--- a/test/end_to_end/test_create_runs.py
+++ b/test/end_to_end/test_create_runs.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from fehm_toolkit.config import FilesConfig, RunConfig
 from fehm_toolkit.fehm_runs import create_run_from_mesh, create_run_from_run
 from fehm_toolkit.fehm_runs.create_run_from_mesh import create_template_input_file
@@ -80,25 +82,25 @@ def test_create_template_input_file(tmp_path):
     output_file = tmp_path / 'test.dat'
     files_config = FilesConfig(
         run_root='run_root',
-        material_zone='material_zone.txt',
-        outside_zone='outside_zone.txt',
-        area='area.txt',
-        rock_properties='rock_properties.txt',
-        conductivity='conductivity.txt',
-        pore_pressure='pore_pressure.txt',
-        permeability='permeability.txt',
-        heat_flux='heat_flux.txt',
-        flow='flow.txt',
-        files='fehmn.files',
-        grid='grid.txt',
-        input='input.txt',
-        output='output.txt',
-        store='store.txt',
-        history='history.txt',
-        water_properties='water_properties.txt',
-        check='check.txt',
-        error='error.txt',
-        final_conditions='final_conditions.txt',
+        material_zone=Path('material_zone.txt'),
+        outside_zone=Path('outside_zone.txt'),
+        area=Path('area.txt'),
+        rock_properties=Path('rock_properties.txt'),
+        conductivity=Path('conductivity.txt'),
+        pore_pressure=Path('pore_pressure.txt'),
+        permeability=Path('permeability.txt'),
+        heat_flux=Path('heat_flux.txt'),
+        flow=Path('flow.txt'),
+        files=Path('fehmn.files'),
+        grid=Path('grid.txt'),
+        input=Path('input.txt'),
+        output=Path('output.txt'),
+        store=Path('store.txt'),
+        history=Path('history.txt'),
+        water_properties=Path('water_properties.txt'),
+        check=Path('check.txt'),
+        error=Path('error.txt'),
+        final_conditions=Path('final_conditions.txt'),
     )
     create_template_input_file(files_config, output_file=output_file)
     assert output_file.read_text() == (

--- a/test/fehm_runs/test_create_run_from_mesh.py
+++ b/test/fehm_runs/test_create_run_from_mesh.py
@@ -1,10 +1,76 @@
+from pathlib import Path
+
 from fehm_toolkit.config import ModelConfig, RockPropertiesConfig, RunConfig
-from fehm_toolkit.fehm_runs.create_run_from_mesh import build_template_from_type
+from fehm_toolkit.fehm_runs.create_run_from_mesh import build_template_from_type, get_template_files_config
 
 
 def test_build_template_from_model_config():
     template = build_template_from_type(ModelConfig)
     assert template == {'kind': 'replace__str', 'params': {}}
+
+
+def test_get_template_files_config():
+    template = get_template_files_config(
+        file_pairs_by_file_type={
+            'material_zone': (Path('mesh/mesh_material.zone'), Path('cond/cond_material.zone')),
+            'area': (Path('mesh/mesh.area'), Path('cond/cond.area')),
+        },
+        run_root=None,
+    )
+    assert template == dict(
+        run_root='run',
+        material_zone='cond_material.zone',
+        outside_zone='outside_zone.txt',
+        area='cond.area',
+        rock_properties='rock_properties.txt',
+        conductivity='conductivity.txt',
+        pore_pressure='pore_pressure.txt',
+        permeability='permeability.txt',
+        files='fehmn.files',
+        grid='grid.txt',
+        input='input.txt',
+        output='output.txt',
+        store='store.txt',
+        history='history.txt',
+        water_properties='water_properties.txt',
+        check='check.txt',
+        error='error.txt',
+        final_conditions='final_conditions.txt',
+        flow='flow.txt',
+        heat_flux='heat_flux.txt',
+    )
+
+
+def test_get_template_files_config_run_root():
+    template = get_template_files_config(
+        file_pairs_by_file_type={
+            'outside_zone': (Path('mesh/mesh_outside.zone'), Path('cond/cond_outside.zone')),
+            'grid': (Path('mesh/mesh.fehmn'), Path('cond/cond.fehm')),
+        },
+        run_root='my_run',
+    )
+    assert template == dict(
+        run_root='my_run',
+        material_zone='my_run_material.zone',
+        outside_zone='cond_outside.zone',
+        area='my_run.area',
+        rock_properties='my_run.rock',
+        conductivity='my_run.cond',
+        pore_pressure='my_run.ppor',
+        permeability='my_run.perm',
+        files='fehmn.files',
+        grid='cond.fehm',
+        input='my_run.dat',
+        output='my_run.out',
+        store='my_run.stor',
+        history='my_run.hist',
+        water_properties='my_run.wpi',
+        check='my_run.chk',
+        error='my_run.err',
+        final_conditions='my_run.fin',
+        flow='my_run.flow',
+        heat_flux='my_run.hflx',
+    )
 
 
 def test_build_template_from_rock_properties_config():


### PR DESCRIPTION
Fix a bug in `create_run_from_mesh` where the files template had some null values. This cleans up the code, fixes the bug, and adds a test to ensure this is behaving as expected going forward.