### PR TITLE
Optional pressure interpolation

### DIFF
--- a/fehm_toolkit/config/pressure_config.py
+++ b/fehm_toolkit/config/pressure_config.py
@@ -7,13 +7,15 @@ from .model_config import ModelConfig
 @dataclass
 class PressureConfig:
     pressure_model: ModelConfig
-    interpolation_model: ModelConfig
+    interpolation_model: ModelConfig = None
     sampling_model: Optional[ModelConfig] = None
 
     @classmethod
     def from_dict(cls, dct):
         return cls(
             pressure_model=ModelConfig.from_dict(dct['pressure_model']),
-            interpolation_model=ModelConfig.from_dict(dct['interpolation_model']),
+            interpolation_model=(
+                ModelConfig.from_dict(dct['interpolation_model']) if dct.get('interpolation_model') else None
+            ),
             sampling_model=ModelConfig.from_dict(dct['sampling_model']) if dct.get('sampling_model') else None,
         )

--- a/fehm_toolkit/config/run_config.py
+++ b/fehm_toolkit/config/run_config.py
@@ -36,7 +36,7 @@ class RunConfig:
     def to_yaml(self, config_file: Path):
         files_config_relative_to_output = self.files_config.relative_to(config_file.parent)
 
-        run_config_dict = dataclasses.asdict(self)
+        run_config_dict = dataclasses.asdict(self, dict_factory=lambda x: {k: v for (k, v) in x if v is not None})
         run_config_dict['files_config'] = {
             k: str(v) for k, v in dataclasses.asdict(files_config_relative_to_output).items() if v is not None
         }

--- a/fehm_toolkit/file_interface/legacy_config/ipi_reader.py
+++ b/fehm_toolkit/file_interface/legacy_config/ipi_reader.py
@@ -21,5 +21,4 @@ def read_legacy_ipi_config(ipi_file: Path) -> PressureConfig:
                 'reference_temperature_degC': reference_temperature,
             },
         ),
-        interpolation_model=ModelConfig(kind='none', params={}),
     )

--- a/test/config/fixtures/flat_box_cond.yaml
+++ b/test/config/fixtures/flat_box_cond.yaml
@@ -24,9 +24,6 @@ heat_flux_config:
     params:
       constant: 3.67e-07
 pressure_config:
-  interpolation_model:
-    kind: none
-    params: {}
   pressure_model:
     kind: depth
     params:
@@ -34,7 +31,6 @@ pressure_config:
       reference_temperature_degC: 2.0
       reference_z: 4700.0
       z_interval_m: 5.0
-  sampling_model: null
 rock_properties_config:
   compressibility_configs:
   - property_model:

--- a/test/config/test_legacy_readers.py
+++ b/test/config/test_legacy_readers.py
@@ -42,7 +42,7 @@ def test_read_legacy_ipi_config_jdf(fixture_dir):
             'reference_temperature_degC': 2,
         }
     )
-    assert config.interpolation_model == ModelConfig(kind='none', params={})
+    assert config.interpolation_model is None
     assert config.sampling_model is None
 
 
@@ -57,7 +57,7 @@ def test_read_legacy_ipi_config_np(fixture_dir):
             'reference_temperature_degC': 2,
         }
     )
-    assert config.interpolation_model == ModelConfig(kind='none', params={})
+    assert config.interpolation_model is None
     assert config.sampling_model is None
 
 

--- a/test/end_to_end/fixtures/flat_box/cond/config.yaml
+++ b/test/end_to_end/fixtures/flat_box/cond/config.yaml
@@ -27,9 +27,6 @@ heat_flux_config:
       crustal_age_sign: 1
       spread_rate_mm_per_year: 28.57
 pressure_config:
-  interpolation_model:
-    kind: none
-    params: {}
   pressure_model:
     kind: depth
     params:
@@ -37,7 +34,6 @@ pressure_config:
       reference_temperature_degC: 2.0
       reference_z: 4450.0
       z_interval_m: 5.0
-  sampling_model: null
 rock_properties_config:
   compressibility_configs:
   - property_model:

--- a/test/end_to_end/fixtures/flat_box/p12/config.yaml
+++ b/test/end_to_end/fixtures/flat_box/p12/config.yaml
@@ -29,9 +29,6 @@ heat_flux_config:
       crustal_age_sign: 1
       spread_rate_mm_per_year: 28.57
 pressure_config:
-  interpolation_model:
-    kind: none
-    params: {}
   pressure_model:
     kind: depth
     params:
@@ -39,7 +36,6 @@ pressure_config:
       reference_temperature_degC: 2.0
       reference_z: 4450.0
       z_interval_m: 5.0
-  sampling_model: null
 rock_properties_config:
   compressibility_configs:
   - property_model:

--- a/test/end_to_end/fixtures/outcrop_2d/cond/config.yaml
+++ b/test/end_to_end/fixtures/outcrop_2d/cond/config.yaml
@@ -24,9 +24,6 @@ heat_flux_config:
     params:
       constant: 3.67e-07
 pressure_config:
-  interpolation_model:
-    kind: none
-    params: {}
   pressure_model:
     kind: depth
     params:
@@ -34,7 +31,6 @@ pressure_config:
       reference_temperature_degC: 2.0
       reference_z: 4700.0
       z_interval_m: 5.0
-  sampling_model: null
 rock_properties_config:
   compressibility_configs:
   - property_model:

--- a/test/end_to_end/fixtures/outcrop_2d/p13/config.yaml
+++ b/test/end_to_end/fixtures/outcrop_2d/p13/config.yaml
@@ -26,9 +26,6 @@ heat_flux_config:
     params:
       constant: 3.67e-07
 pressure_config:
-  interpolation_model:
-    kind: none
-    params: {}
   pressure_model:
     kind: depth
     params:
@@ -36,7 +33,6 @@ pressure_config:
       reference_temperature_degC: 2.0
       reference_z: 4700.0
       z_interval_m: 5.0
-  sampling_model: null
 rock_properties_config:
   compressibility_configs:
   - property_model:

--- a/test/end_to_end/fixtures/warped_box/cond/config.yaml
+++ b/test/end_to_end/fixtures/warped_box/cond/config.yaml
@@ -27,9 +27,6 @@ heat_flux_config:
       crustal_age_sign: 1
       spread_rate_mm_per_year: 10.0
 pressure_config:
-  interpolation_model:
-    kind: none
-    params: {}
   pressure_model:
     kind: depth
     params:
@@ -37,7 +34,6 @@ pressure_config:
       reference_temperature_degC: 3.0
       reference_z: 20.0
       z_interval_m: 1.0
-  sampling_model: null
 rock_properties_config:
   compressibility_configs:
   - property_model:


### PR DESCRIPTION
While writing documentation for the PressureConfig, I realised that the `interpolation_model` would be easier to understand if it were simply optional, like the sampling config. This change makes it optional, adjusts the code and validators to handle this, and modifies fixtures and legacy readers to reflect this new default.

I've also made a slightly more general change to the RunConfig `to_yaml` method, to have it drop any `null` values when writing to disk, this is preferred by the YAML spec and removes clutter.