### PR TITLE
Modify input file on run_from_run

### DIFF
--- a/fehm_toolkit/file_manipulation/modify_fehm_input_file.py
+++ b/fehm_toolkit/file_manipulation/modify_fehm_input_file.py
@@ -4,25 +4,26 @@ from typing import Optional
 
 
 def write_modified_fehm_input_file(
-    base_fehm_input_file: Path,
-    out_file: Path,
+    base_input_file: Path,
+    output_file: Path,
+    *,
     initial_timestep_days: float = None,
     initial_simulation_time_days: float = None,
     file_mapping: Optional[dict[str, str]] = None,
-) -> str:
+):
     """Write a control file (.dat) from the (modified) contents of another control file."""
-    fehm_input_content = base_fehm_input_file.read_text()
+    content = base_input_file.read_text()
     if file_mapping:
-        fehm_input_content = _replace_mapped_files(fehm_input_content, file_mapping)
+        content = _replace_mapped_files(content, file_mapping)
 
     if initial_timestep_days is not None or initial_simulation_time_days is not None:
-        fehm_input_content = _replace_timing(
-            fehm_input_content,
+        content = _replace_timing(
+            content,
             initial_timestep_days=initial_timestep_days,
             initial_simulation_time_days=initial_simulation_time_days,
         )
 
-    out_file.write_text(fehm_input_content)
+    output_file.write_text(content)
 
 
 def _replace_mapped_files(content: str, file_mapping: dict[str, str]) -> str:

--- a/test/end_to_end/test_create_runs.py
+++ b/test/end_to_end/test_create_runs.py
@@ -141,7 +141,12 @@ def test_create_run_from_run(tmp_path, end_to_end_fixture_dir):
     assert new_config.files_config.grid.exists()
     assert new_config.files_config.store.exists()
     assert new_config.files_config.files.exists()
+
     assert new_config.files_config.input.exists()
+    input_content = new_config.files_config.input.read_text()
+    assert new_config.files_config.permeability.name in input_content
+    assert new_config.files_config.conductivity.name in input_content
+    assert new_config.files_config.rock_properties.name in input_content
 
     assert new_config.files_config.grid.read_text() == run_config.files_config.grid.read_text()
     assert new_config.files_config.outside_zone.read_text() == run_config.files_config.outside_zone.read_text()

--- a/test/end_to_end/test_written_files.py
+++ b/test/end_to_end/test_written_files.py
@@ -159,8 +159,8 @@ def test_write_modified_fehm_input_against_fixture(
     file_extensions = {'perm', 'rock', 'cond', 'ppor', 'hflx', 'flow'}
 
     write_modified_fehm_input_file(
-        base_fehm_input_file=model_dir / f'{model_name}.dat',
-        out_file=output_file,
+        base_input_file=model_dir / f'{model_name}.dat',
+        output_file=output_file,
         file_mapping={f'{model_name}.{ext}': f'test.{ext}' for ext in file_extensions},
     )
 
@@ -187,8 +187,8 @@ def test_write_modified_fehm_input_with_timing_against_fixture(
     output_file = tmp_path / 'test.dat'
 
     write_modified_fehm_input_file(
-        base_fehm_input_file=model_dir / f'{model_name}.dat',
-        out_file=output_file,
+        base_input_file=model_dir / f'{model_name}.dat',
+        output_file=output_file,
         initial_timestep_days=7300,
         initial_simulation_time_days=1234,
     )


### PR DESCRIPTION
This ensures any copied files that are referenced in the FEHM input file (e.g. `cond.dat`) are renamed appropriately. I've updated existing tests, and added lines to end-to-end tests to ensure this has been done correctly.