### PR TITLE
Files config validation

### DIFF
--- a/fehm_toolkit/config/files_config.py
+++ b/fehm_toolkit/config/files_config.py
@@ -29,6 +29,9 @@ class FilesConfig:
     heat_flux: Optional[Path] = None
     initial_conditions: Optional[Path] = None
 
+    def __post_init__(self):
+        self.validate()
+
     @classmethod
     def from_dict(cls, dct: dict, files_relative_to: Optional[Path] = None):
         if files_relative_to is None:
@@ -48,9 +51,15 @@ class FilesConfig:
         })
 
     def validate(self):
-        self._assert_specified_paths_exist()
+        seen = set()
+        for path in dataclasses.asdict(self).values():
+            if path is None:
+                continue
+            if path in seen:
+                raise ValueError(f'Invalid FilesConfig, file duplicated: {path}')
+            seen.add(path)
 
-    def _assert_specified_paths_exist(self):
+    def assert_specified_paths_exist(self):
         does_not_exist = set()
         for key, path in dataclasses.asdict(self).items():
             if key == 'run_root':

--- a/fehm_toolkit/fehm_runs/create_config_for_legacy_run.py
+++ b/fehm_toolkit/fehm_runs/create_config_for_legacy_run.py
@@ -70,7 +70,7 @@ def create_config_for_legacy_run(
         heat_flux=heat_flux_file or get_unique_file(directory, '*.hflx', optional=True),
         initial_conditions=initial_conditions_file or get_unique_file(directory, '*.ini', optional=True),
     )
-    files_config.validate()
+    files_config.assert_specified_paths_exist()
 
     run_config = RunConfig(
         heat_flux_config=read_legacy_hfi_config(hfi_file),

--- a/test/config/test_config_objects.py
+++ b/test/config/test_config_objects.py
@@ -26,8 +26,8 @@ def config_dict(fixture_dir):
 def files_config_dict():
     return {
       'run_root': 'run_root',
-      'material_zone': 'run_root.zone',
-      'outside_zone': 'run_root.zone',
+      'material_zone': 'run_root_material.zone',
+      'outside_zone': 'run_root_outside.zone',
       'area': 'run_root.area',
       'initial_conditions': 'run_root.ini',
       'final_conditions': 'run_root.fin',
@@ -203,7 +203,7 @@ def test_run_config_omits_none_files(tmp_path, config_dict):
 def test_files_config(files_config_dict):
     config = FilesConfig.from_dict(files_config_dict)
     assert config.run_root == 'run_root'
-    assert config.material_zone == Path.cwd() / 'run_root.zone'
+    assert config.material_zone == Path.cwd() / 'run_root_material.zone'
     assert config.area == Path.cwd() / 'run_root.area'
     assert config.water_properties == Path.cwd() / '../../end_to_end/fixtures/nist120-1800.out'
     for k, v in asdict(config).items():


### PR DESCRIPTION
This creates a validation method to ensure that no two paths in the `FilesConfig` are identical. This validation method is called every time a `FilesConfig` object is created.

We previously had a validation method that was actually performing a more niche assertion, I've renamed this to make it clearer.