### PR TITLE
Boundaries config

### DIFF
--- a/fehmtk/config/__init__.py
+++ b/fehmtk/config/__init__.py
@@ -1,3 +1,4 @@
+from .boundaries_config import BoundariesConfig
 from .files_config import FilesConfig
 from .heat_flux_config import HeatFluxConfig
 from .model_config import ModelConfig

--- a/fehmtk/config/boundaries_config.py
+++ b/fehmtk/config/boundaries_config.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+from typing import Union
+
+from .model_config import ModelConfig
+
+
+@dataclass
+class FlowConfig:
+    boundary_model: ModelConfig
+    zones: list[Union[int, str]]
+
+    @classmethod
+    def from_dict(cls, dct):
+        return cls(
+            boundary_model=ModelConfig.from_dict(dct['property_model']),
+            zones=dct['zones'],
+        )
+
+
+@dataclass
+class BoundariesConfig:
+    flow_configs: list[FlowConfig]
+
+    @classmethod
+    def from_dict(cls, dct):
+        return cls(
+            flow_configs=[FlowConfig.from_dict(c) for c in dct['flow_configs']],
+        )

--- a/fehmtk/config/boundaries_config.py
+++ b/fehmtk/config/boundaries_config.py
@@ -12,7 +12,7 @@ class FlowConfig:
     @classmethod
     def from_dict(cls, dct):
         return cls(
-            boundary_model=ModelConfig.from_dict(dct['property_model']),
+            boundary_model=ModelConfig.from_dict(dct['boundary_model']),
             zones=dct['zones'],
         )
 

--- a/fehmtk/config/run_config.py
+++ b/fehmtk/config/run_config.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 import yaml
 
+from .boundaries_config import BoundariesConfig
 from .files_config import FilesConfig
 from .heat_flux_config import HeatFluxConfig
 from .pressure_config import PressureConfig
@@ -16,6 +17,7 @@ class RunConfig:
     files_config: FilesConfig
     heat_flux_config: HeatFluxConfig
     rock_properties_config: RockPropertiesConfig
+    boundaries_config: Optional[BoundariesConfig] = None
     pressure_config: Optional[PressureConfig] = None
 
     @classmethod
@@ -24,6 +26,9 @@ class RunConfig:
             files_config=FilesConfig.from_dict(dct['files_config'], files_relative_to),
             heat_flux_config=HeatFluxConfig.from_dict(dct['heat_flux_config']),
             rock_properties_config=RockPropertiesConfig.from_dict(dct['rock_properties_config']),
+            boundaries_config=(
+                BoundariesConfig.from_dict(dct['boundaries_config']) if dct.get('boundaries_config') else None
+            ),
             pressure_config=PressureConfig.from_dict(dct['pressure_config']) if dct.get('pressure_config') else None,
         )
 

--- a/test/end_to_end/fixtures/outcrop_2d/cond/config.yaml
+++ b/test/end_to_end/fixtures/outcrop_2d/cond/config.yaml
@@ -23,6 +23,15 @@ heat_flux_config:
     kind: constant_MW_per_m2
     params:
       constant: 3.67e-07
+boundaries_config:
+  flow_configs:
+  - boundary_model:
+      kind: 'open_flow'
+      params:
+        input_fluid_temp_degC: 2
+        aiped_to_volume_ratio: 1.0e-08
+    zones: ['top']
+
 pressure_config:
   pressure_model:
     kind: depth

--- a/test/end_to_end/test_create_config_for_legacy_run.py
+++ b/test/end_to_end/test_create_config_for_legacy_run.py
@@ -6,9 +6,8 @@ from fehmtk.config import RunConfig
 from fehmtk.fehm_runs.create_config_for_legacy_run import create_config_for_legacy_run
 
 
-@pytest.mark.parametrize('mesh_name', ('flat_box', 'outcrop_2d'))
-def test_create_config_for_legacy_run_cond(tmp_path, end_to_end_fixture_dir, mesh_name):
-    run_directory = end_to_end_fixture_dir / mesh_name / 'cond'
+def test_create_config_for_legacy_run_cond(tmp_path, end_to_end_fixture_dir):
+    run_directory = end_to_end_fixture_dir / 'flat_box' / 'cond'
     tmp_model_dir = tmp_path / 'root' / 'model' / 'run'
     shutil.copytree(run_directory, tmp_model_dir)
     (tmp_model_dir.parent.parent / 'nist120-1800.out').touch()

--- a/test/fehm_runs/test_create_run_from_mesh.py
+++ b/test/fehm_runs/test_create_run_from_mesh.py
@@ -118,7 +118,13 @@ def test_build_template_from_rock_properties_config():
 
 def test_build_template_from_run_config():
     template = build_template_from_type(RunConfig)
-    assert template.keys() == {'files_config', 'heat_flux_config', 'rock_properties_config', 'pressure_config'}
+    assert template.keys() == {
+        'files_config',
+        'heat_flux_config',
+        'rock_properties_config',
+        'boundaries_config',
+        'pressure_config',
+    }
     assert template['heat_flux_config'] == {'heat_flux_model': {'kind': 'replace__str', 'params': {}}}
     for key, value in template['files_config'].items():
         if key == 'run_root':


### PR DESCRIPTION
Add a `boundaries_config` for handling the assignment of boundary conditions. For now, this includes a number of flow configs, each with a model and the zones they apply to. This is being included to support the creation of a tool like `topbc` from before, while allowing it to be configured as well.