### PR TITLE
Add volumes to nodes

### DIFF
--- a/fehmtk/fehm_objects/node.py
+++ b/fehmtk/fehm_objects/node.py
@@ -10,6 +10,7 @@ class Node:
     coordinates: Vector
     outside_area: Vector = None
     depth: float = None
+    volume: float = None
 
     @property
     def x(self) -> float:


### PR DESCRIPTION
This adds volume data from the `.stor` file to Node objects, so it can be accessed in the `topbc` replacement.