### PR TITLE
Flow boundaries command

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,26 @@ heat_flux_config:
 
 See [heat_flux_models.py](fehmtk/preprocessors/heat_flux_models.py) for a full list of supported models and their required params.
 
+#### Boundaries config
+Mapping with a single top level key `flow_configs`, with a list of FlowConfigs as a value:
+```yaml
+boundaries_config:
+  flow_configs:
+  - boundary_model:
+      kind: 'open_flow'
+      params:
+        input_fluid_temp_degC: 2
+        aiped_to_volume_ratio: 1.0e-08
+    outside_zones: ['top']
+    material_zones: []  # these can also be omitted if empty (done with outside_zones below)
+  - boundary_model:
+      kind: 'open_flow'
+      params:
+        input_fluid_temp_degC: 10
+        aiped_to_volume_ratio: 1.0e-08
+    material_zones: [1, 2]
+```
+
 #### Rock properties config
 Mapping with keys for each property config (`compressibility_config`, `conductivity_config`, `permeability_config`, `porosity_config`, `specific_heat_config`), as well as the `zone_assignment_order`. The assignment order can be important in cases where some nodes are members of more than one zone, and for these nodes later zone assignments will overwrite earlier ones.
 

--- a/fehmtk/command_line_interface.py
+++ b/fehmtk/command_line_interface.py
@@ -65,6 +65,19 @@ def entry_point():
     ))
     run_from_run.set_defaults(func=create_run_from_run)
 
+    rock_properties = subparsers.add_parser('rock_properties', help='Generate rock properties from configuration')
+    rock_properties.add_argument('config_file', type=Path, help='Run configuration (config.yaml) file')
+    rock_properties.set_defaults(func=generate_rock_properties)
+
+    heat_in = subparsers.add_parser('heat_in', help='Generate input heat flux based on run configuration')
+    heat_in.add_argument('config_file', type=Path, help='Run configuration (config.yaml) file')
+    heat_in.add_argument('--plot', action='store_true', help='Flag to plot the heat flux')
+    heat_in.set_defaults(func=generate_input_heat_flux)
+
+    flow = subparsers.add_parser('flow', help='Generate flow boundary conditions based on run configuration')
+    flow.add_argument('config_file', type=Path, help='Run configuration (config.yaml) file')
+    flow.set_defaults(func=generate_flow_boundaries)
+
     create_config = subparsers.add_parser(
         'legacy_config',
         help='Create config.yaml from legacy configuration files (e.g. .hfi/.rpi/.ipi)',
@@ -94,23 +107,6 @@ def entry_point():
     create_config.add_argument('--heat_flux_file', type=Path, help='Heat flux file')
     create_config.add_argument('--initial_conditions_file', type=Path, help='Initial_conditions file')
     create_config.set_defaults(func=create_config_for_legacy_run)
-
-    rock_properties = subparsers.add_parser('rock_properties', help='Generate rock properties from configuration')
-    rock_properties.add_argument('config_file', type=Path, help='Run configuration (config.yaml) file')
-    rock_properties.set_defaults(func=generate_rock_properties)
-
-    heat_in = subparsers.add_parser('heat_in', help='Generate input heat flux based on run configuration')
-    heat_in.add_argument('config_file', type=Path, help='Run configuration (.yaml/.hfi) file')
-    heat_in.add_argument('--plot', action='store_true', help='Flag to plot the heat flux')
-    heat_in.set_defaults(func=generate_input_heat_flux)
-
-    pressure = subparsers.add_parser(
-        'hydrostat',
-        help='Generate hydrostatic pressures by interpolating and bootstrapping down the water column',
-    )
-    pressure.add_argument('config_file', type=Path, help='Run configuration (config.yaml) file')
-    pressure.add_argument('output_file', type=Path, help='Pressure output (.iap/.icp) to be written')
-    pressure.set_defaults(func=generate_hydrostatic_pressure)
 
     zones = subparsers.add_parser(
         'append_zones',

--- a/fehmtk/command_line_interface.py
+++ b/fehmtk/command_line_interface.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from .fehm_runs import create_config_for_legacy_run, create_run_from_mesh, create_run_from_run
 from .preprocessors import (
+    generate_flow_boundaries,
     generate_hydrostatic_pressure,
     generate_input_heat_flux,
     generate_rock_properties,
@@ -77,6 +78,14 @@ def entry_point():
     flow = subparsers.add_parser('flow', help='Generate flow boundary conditions based on run configuration')
     flow.add_argument('config_file', type=Path, help='Run configuration (config.yaml) file')
     flow.set_defaults(func=generate_flow_boundaries)
+
+    pressure = subparsers.add_parser(
+        'hydrostat',
+        help='Generate hydrostatic pressures by interpolating and bootstrapping down the water column',
+    )
+    pressure.add_argument('config_file', type=Path, help='Run configuration (config.yaml) file')
+    pressure.add_argument('output_file', type=Path, help='Pressure output (.iap/.icp) to be written')
+    pressure.set_defaults(func=generate_hydrostatic_pressure)
 
     create_config = subparsers.add_parser(
         'legacy_config',


### PR DESCRIPTION
This creates a command `flow` for generating flow boundaries (typically `.flow` files). This is the replacement for `topbc`.

It looks like this in the command prompt:
```zsh
$ fehmtk flow --help
usage: fehmtk flow [-h] config_file

positional arguments:
  config_file  Run configuration (config.yaml) file

optional arguments:
  -h, --help   show this help message and exit
```

Rather than defaulting values, this utility requires a `boundaries_config` entry in the `config.yaml` file to specify details. Currently this only supports the same as topbc, where a temperature and aiped ratio are specified. See readme changes for an example.