### PR TITLE
Check history

### DIFF
--- a/fehmtk/command_line_interface.py
+++ b/fehmtk/command_line_interface.py
@@ -9,6 +9,9 @@ from .preprocessors import (
     generate_input_heat_flux,
     generate_rock_properties,
 )
+from .postprocessors import (
+    check_history,
+)
 from .file_manipulation import append_zones
 
 
@@ -78,6 +81,24 @@ def entry_point():
     flow = subparsers.add_parser('flow', help='Generate flow boundary conditions based on run configuration')
     flow.add_argument('config_file', type=Path, help='Run configuration (config.yaml) file')
     flow.set_defaults(func=generate_flow_boundaries)
+
+    history = subparsers.add_parser('check_history', help='Summary plots of run history file')
+    history.add_argument('config_file', type=Path, help='Run configuration (config.yaml) file')
+    history.add_argument(
+        '--last_fraction',
+        type=float,
+        help='Truncates plots, showing only last fraction of data (e.g., .5 displays the last half, .2 the last fifth)',
+        default=0.9,
+    )
+    history.add_argument('--nodes', type=int, nargs='+', help='Space-separated list of node numbers, only plot these')
+    history.add_argument(
+        '--fields',
+        type=str,
+        nargs='+',
+        help='Space-separated list of fields, only plot these',
+        default=['temperature(deg C)', 'total pressure(Mpa)'],
+    )
+    history.set_defaults(func=check_history)
 
     pressure = subparsers.add_parser(
         'hydrostat',

--- a/fehmtk/command_line_interface.py
+++ b/fehmtk/command_line_interface.py
@@ -28,6 +28,7 @@ def entry_point():
             'Create a run directory by copying files from a mesh direcotry. File name roots are replaced '
             'if run_root is set, otherwise file names are persisted.'
         ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     run_from_mesh.add_argument('mesh_directory', type=Path, help='Mesh directory containing source files')
     run_from_mesh.add_argument('target_directory', type=Path, help='Destination run directory to be created')
@@ -82,7 +83,11 @@ def entry_point():
     flow.add_argument('config_file', type=Path, help='Run configuration (config.yaml) file')
     flow.set_defaults(func=generate_flow_boundaries)
 
-    history = subparsers.add_parser('check_history', help='Summary plots of run history file')
+    history = subparsers.add_parser(
+        'check_history',
+        help='Summary plots of run history file',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     history.add_argument('config_file', type=Path, help='Run configuration (config.yaml) file')
     history.add_argument(
         '--last_fraction',
@@ -95,7 +100,7 @@ def entry_point():
         '--fields',
         type=str,
         nargs='+',
-        help='Space-separated list of fields, only plot these',
+        help='Space-separated list of fields, only plot these - wrap fields with spaces in double-quotes',
         default=['temperature(deg C)', 'total pressure(Mpa)'],
     )
     history.set_defaults(func=check_history)

--- a/fehmtk/postprocessors/__init__.py
+++ b/fehmtk/postprocessors/__init__.py
@@ -1,0 +1,1 @@
+from .check_history import check_history

--- a/fehmtk/postprocessors/check_history.py
+++ b/fehmtk/postprocessors/check_history.py
@@ -29,8 +29,6 @@ def check_history(
 ):
     logger.info(f'Reading configuration file: {config_file}')
     config = RunConfig.from_yaml(config_file)
-    if not config.files_config.history:
-        raise ValueError(f'No history file defined in {config_file}.')
 
     history = read_history(
         config.files_config.history,

--- a/fehmtk/postprocessors/check_history.py
+++ b/fehmtk/postprocessors/check_history.py
@@ -1,0 +1,77 @@
+import logging
+from pathlib import Path
+from typing import Optional
+
+from matplotlib import pyplot as plt
+import pandas as pd
+import seaborn as sns
+
+from fehmtk.config import RunConfig
+from fehmtk.file_interface import read_history
+
+logger = logging.getLogger(__name__)
+
+PLOT_AXES_MAPPING = {
+    'flow enthalpy(Mj/kg)': r'$H\:(\frac{Mj}{kg})$',
+    'flow(kg/s)': r'$Q\:(\frac{kg}{s})$',
+    'temperature(deg C)': r'$T\:( \degree{C})$',
+    'total pressure(Mpa)': r'$P\:(MPa)$',
+    'capillary pressure(Mpa)': r'$P_{cap}\:(MPa)$',
+    'saturation(kg/kg)': r'$S$',
+}
+
+
+def check_history(
+    config_file: Path,
+    last_fraction: Optional[float] = None,
+    nodes: Optional[list[int]] = None,
+    fields: Optional[list[str]] = None,
+):
+    logger.info(f'Reading configuration file: {config_file}')
+    config = RunConfig.from_yaml(config_file)
+    if not config.files_config.history:
+        raise ValueError(f'No history file defined in {config_file}.')
+
+    history = read_history(
+        config.files_config.history,
+        last_fraction=last_fraction,
+        read_nodes=nodes,
+        read_fields=fields,
+    )
+    if len(history.columns) == 1:
+        raise ValueError(f'No node data found in history file {config.files_config.history}')
+    if fields is None:
+        fields = [field for field in history.columns if field not in ('time_days', 'node')]
+
+    plot_history(history, fields)
+
+
+def plot_history(history: pd.DataFrame, fields: list[str]):
+    n_nodes = history.node.nunique()
+
+    history = history.astype(float)  # Plotting doesn't play nice with Decimal types
+    history['node'] = history.node.astype(int).astype(str)  # Remove trailing zeroes, treat as categorical
+    history['time_years'] = history.time_days / 365
+
+    sns.set_palette('muted')
+    fig, axs = plt.subplots(len(fields), 1, figsize=(6, 2 + len(fields)), constrained_layout=True, sharex=True)
+    for i, (field, ax) in enumerate(zip(fields, axs)):
+        sns.lineplot(data=history, x='time_years', y=field, hue='node', ax=ax, legend=i == 0)
+        ax.set_xlabel(r'$t\:(years)$')
+        ax.set_ylabel(PLOT_AXES_MAPPING.get(field, field))
+
+    delta_history = history[['node', 'time_years']][n_nodes:]
+    delta_history['delta_time_years'] = history.groupby('node').time_years.diff()
+    for field in fields:
+        delta_history[field] = history.groupby('node')[field].diff()
+
+    fig, axs = plt.subplots(len(fields) + 1, 1, figsize=(6, 4 + len(fields)), constrained_layout=True, sharex=True)
+    for i, (field, ax) in enumerate(zip(fields, axs)):
+        sns.lineplot(data=delta_history, x='time_years', y=field, hue='node', ax=ax, legend=i == 0)
+        ax.set_ylabel(r'$\Delta\:$' + PLOT_AXES_MAPPING.get(field, field))
+
+    sns.lineplot(data=delta_history, x='time_years', y='delta_time_years', hue='node', ax=axs[-1], legend=False)
+    axs[-1].set_xlabel(r'$t\:(years)$')
+    axs[-1].set_ylabel(r'$\Delta\:t\:(years)$')
+
+    plt.show()

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,9 +30,10 @@ packages = find:
 platforms = any
 include_package_data = True
 install_requires =
-    numpy>1.22,<1.23
-    pandas>1.4,<1.5
-    matplotlib>3.5,<3.6
+    numpy>=1.22,<1.23
+    pandas>=1.4,<1.5
+    matplotlib>=3.5,<3.6
+    seaborn>=0.12,<0.13
     scipy>=1.8,<1.9
     PyYAML>=6.0,<6.1
 python_requires = >=3.9


### PR DESCRIPTION
This creates a command and code to generate plots based on the history file:

This supports truncating to only look at the final fraction of data with `last_fraction` and subsetting to specific nodes or fields. Currently `fields` defaults to T and P only, but you can specify these explicitly if you want to monitor e.g. flow enthalpy or saturation.

```(fehmtk) MacBook-Pro-3 fehmToolkit$ fehmtk check_history --help
usage: fehmtk check_history [-h] [--last_fraction LAST_FRACTION] [--nodes NODES [NODES ...]]
                            [--fields FIELDS [FIELDS ...]]
                            config_file

positional arguments:
  config_file           Run configuration (config.yaml) file

optional arguments:
  -h, --help            show this help message and exit
  --last_fraction LAST_FRACTION
                        Truncates plots, showing only last fraction of data (e.g., .5 displays the
                        last half, .2 the last fifth) (default: 0.9)
  --nodes NODES [NODES ...]
                        Space-separated list of node numbers, only plot these (default: None)
  --fields FIELDS [FIELDS ...]
                        Space-separated list of fields, only plot these - wrap fields with spaces in
                        double-quotes (default: ['temperature(deg C)', 'total pressure(Mpa)'])
```

This generates two plots, one for raw values, and another for deltas - including time:
## Raw value plot
![Figure_1](https://user-images.githubusercontent.com/13643861/196685267-21b97512-be20-4689-9fcf-4ee9a83c8266.png)

## Delta value plot
<img src="https://user-images.githubusercontent.com/13643861/196685283-70fd5aa9-e67b-4e5c-ad13-e4cd12563228.png" width="600" height="600">
