### PR TITLE
Crustal age dimension

### DIFF
--- a/fehmtk/file_interface/legacy_config/hfi_reader.py
+++ b/fehmtk/file_interface/legacy_config/hfi_reader.py
@@ -38,6 +38,7 @@ def read_legacy_hfi_config(hfi_file: Path) -> HeatFluxConfig:
 
 def _get_crustal_age_model_parameters(processed_text: str, hfi_file: Path) -> dict[str, Decimal]:
     return {
+        'crustal_age_dimension': 'x',
         'crustal_age_sign': _get_crustal_age_sign(processed_text, hfi_file),
         'spread_rate_mm_per_year': _get_spread_rate(processed_text, hfi_file),
         'coefficient_MW': _get_heatflux_coefficient(processed_text, hfi_file),

--- a/fehmtk/preprocessors/heat_flux_models.py
+++ b/fehmtk/preprocessors/heat_flux_models.py
@@ -24,12 +24,18 @@ def _crustal_age_heatflux(node: Node, params: dict) -> Decimal:
     boundary_distance_to_ridge_m  [D]  (numeric)
     spread_rate_mm_per_year       [R]  (numeric)
     crustal_age_sign              [±]  (+, -, 1, or -1)
+    crustal_age_dimension         [x]  (x, y, or z) [default x]
     """
     if params['crustal_age_sign'] not in (1, -1, '+', '-'):
         raise ValueError(f'Invalid crustal_age_sign {params["crustal_age_sign"]}, must be 1, -1, +, or -')
 
     crustal_age_sign = 1 if params['crustal_age_sign'] in (1, '+') else -1
-    distance_from_boundary_m = crustal_age_sign * node.x
+
+    crustal_age_dimension = params.get('crustal_age_dimension', 'x')
+    if crustal_age_dimension not in ('x', 'y', 'z'):
+        raise ValueError(f'Invalid crustal_age_dimension: {crustal_age_dimension}')
+    distance_from_boundary_m = crustal_age_sign * getattr(node, crustal_age_dimension)
+
     distance_from_ridge_m = params['boundary_distance_to_ridge_m'] + distance_from_boundary_m
     age_ma = 1 / (params['spread_rate_mm_per_year'] * Decimal('1E3')) * distance_from_ridge_m
     heatflux_per_m2 = params['coefficient_MW'] / age_ma ** Decimal('0.5')

--- a/test/config/fixtures/flat_box_config.yaml
+++ b/test/config/fixtures/flat_box_config.yaml
@@ -26,6 +26,7 @@ heat_flux_config:
     kind: crustal_age
     params:
       crustal_age_sign: 1
+      crustal_age_dimension: x
       spread_rate_mm_per_year: 28.57
       coefficient_MW: 0.367E-6
       boundary_distance_to_ridge_m: 60000

--- a/test/config/test_legacy_readers.py
+++ b/test/config/test_legacy_readers.py
@@ -16,6 +16,7 @@ def test_read_legacy_hfi_config_jdf(fixture_dir):
     model_config = config.heat_flux_model
     assert model_config.params == {
         'crustal_age_sign': Decimal('1'),
+        'crustal_age_dimension': 'x',
         'spread_rate_mm_per_year': Decimal('28.57'),
         'coefficient_MW': Decimal('0.367E-6'),
         'boundary_distance_to_ridge_m': Decimal('60000'),
@@ -27,6 +28,7 @@ def test_read_legacy_hfi_config_np(fixture_dir):
     model_config = config.heat_flux_model
     assert model_config.params == {
         'crustal_age_sign': Decimal('-1'),
+        'crustal_age_dimension': 'x',
         'spread_rate_mm_per_year': Decimal('17'),
         'coefficient_MW': Decimal('0.5E-6'),
         'boundary_distance_to_ridge_m': Decimal('144000'),

--- a/test/end_to_end/fixtures/flat_box/cond/config.yaml
+++ b/test/end_to_end/fixtures/flat_box/cond/config.yaml
@@ -24,6 +24,7 @@ heat_flux_config:
     params:
       boundary_distance_to_ridge_m: 95000.0
       coefficient_MW: 3.67e-07
+      crustal_age_dimension: x
       crustal_age_sign: 1
       spread_rate_mm_per_year: 28.57
 pressure_config:

--- a/test/end_to_end/fixtures/flat_box/p12/config.yaml
+++ b/test/end_to_end/fixtures/flat_box/p12/config.yaml
@@ -35,6 +35,7 @@ heat_flux_config:
     params:
       boundary_distance_to_ridge_m: 95000.0
       coefficient_MW: 3.67e-07
+      crustal_age_dimension: x
       crustal_age_sign: 1
       spread_rate_mm_per_year: 28.57
 pressure_config:

--- a/test/end_to_end/fixtures/warped_box/cond/config.yaml
+++ b/test/end_to_end/fixtures/warped_box/cond/config.yaml
@@ -25,6 +25,7 @@ heat_flux_config:
       boundary_distance_to_ridge_m: 40000.0
       coefficient_MW: 3.67e-07
       crustal_age_sign: 1
+      crustal_age_dimension: x
       spread_rate_mm_per_year: 10.0
 pressure_config:
   pressure_model:


### PR DESCRIPTION
This allows the `crustal_age` heat flux model handle other dimensions than `x` to be specified. It will still default to `x` if nothing is used.