### PR TITLE
Heat flux rename

### DIFF
--- a/fehmtk/command_line_interface.py
+++ b/fehmtk/command_line_interface.py
@@ -6,7 +6,7 @@ from .fehm_runs import create_config_for_legacy_run, create_run_from_mesh, creat
 from .preprocessors import (
     generate_flow_boundaries,
     generate_hydrostatic_pressure,
-    generate_input_heat_flux,
+    generate_heat_flux_boundaries,
     generate_rock_properties,
 )
 from .postprocessors import (
@@ -78,10 +78,10 @@ def entry_point():
     rock_properties.add_argument('config_file', type=Path, help='Run configuration (config.yaml) file')
     rock_properties.set_defaults(func=generate_rock_properties)
 
-    heat_in = subparsers.add_parser('heat_in', help='Generate input heat flux based on run configuration')
-    heat_in.add_argument('config_file', type=Path, help='Run configuration (config.yaml) file')
-    heat_in.add_argument('--plot', action='store_true', help='Flag to plot the heat flux')
-    heat_in.set_defaults(func=generate_input_heat_flux)
+    heat_flux = subparsers.add_parser('heat_flux', help='Generate heat flux boundaries based on run configuration')
+    heat_flux.add_argument('config_file', type=Path, help='Run configuration (config.yaml) file')
+    heat_flux.add_argument('--plot', action='store_true', help='Flag to plot 2D heat flux maps for outside zones')
+    heat_flux.set_defaults(func=generate_heat_flux_boundaries)
 
     flow = subparsers.add_parser('flow', help='Generate flow boundary conditions based on run configuration')
     flow.add_argument('config_file', type=Path, help='Run configuration (config.yaml) file')

--- a/fehmtk/fehm_runs/create_run_from_mesh.py
+++ b/fehmtk/fehm_runs/create_run_from_mesh.py
@@ -85,7 +85,7 @@ def create_run_from_mesh(
     logger.info(
         'Suggested next steps:\n'
         f'* Update {target_directory / CONFIG_NAME} with desired configuration\n'
-        '* Run heat_in to generate heat flux file\n'
+        '* Run heat_flux to generate heat flux file\n'
         '* Run rock_properties to generate physical properties files\n'
         f'* Update {target_directory / files_config.input.name} with desired configuration\n'
         f'* Run FEHM'

--- a/fehmtk/preprocessors/__init__.py
+++ b/fehmtk/preprocessors/__init__.py
@@ -1,4 +1,4 @@
 from .flow_boundaries import generate_flow_boundaries
-from .heat_in import generate_input_heat_flux
+from .heat_flux_boundaries import generate_heat_flux_boundaries
 from .hydrostatic_pressure import generate_hydrostatic_pressure
 from .rock_properties import generate_rock_properties

--- a/fehmtk/preprocessors/boundary_models.py
+++ b/fehmtk/preprocessors/boundary_models.py
@@ -4,7 +4,21 @@ from typing import Callable
 from fehmtk.fehm_objects import Node
 
 
-def get_heatflux_models_by_kind() -> dict[str, Callable]:
+def get_boundary_model(boundary_kind: str, model_kind: str) -> Callable:
+    if boundary_kind == 'heat_flux':
+        models_by_kind = _get_heat_flux_models_by_kind()
+    elif boundary_kind == 'flow':
+        pass  # TODO(dustin): implement flow boundary models
+    else:
+        raise NotImplementedError(f'No models defined for boundary_kind {boundary_kind}')
+
+    try:
+        return models_by_kind[model_kind]
+    except KeyError:
+        raise NotImplementedError(f'No model defined for kind {model_kind}')
+
+
+def _get_heat_flux_models_by_kind() -> dict[str, Callable]:
     return {
         'crustal_age': _crustal_age_heatflux,
         'constant_MW_per_m2': _constant_MW_per_m2,

--- a/fehmtk/preprocessors/heat_flux_boundaries.py
+++ b/fehmtk/preprocessors/heat_flux_boundaries.py
@@ -15,7 +15,7 @@ from .heat_flux_models import get_heatflux_models_by_kind
 logger = logging.getLogger(__name__)
 
 
-def generate_input_heat_flux(config_file: Path, plot: bool = False):
+def generate_heat_flux_boundaries(config_file: Path, plot: bool = False):
     logger.info(f'Reading configuration file: {config_file}')
     config = RunConfig.from_yaml(config_file)
     if not config.files_config.heat_flux:

--- a/fehmtk/preprocessors/heat_flux_boundaries.py
+++ b/fehmtk/preprocessors/heat_flux_boundaries.py
@@ -6,11 +6,11 @@ from matplotlib import cm, colors, pyplot as plt
 import pandas as pd
 from scipy.spatial import Voronoi, voronoi_plot_2d
 
-from fehmtk.config import HeatFluxConfig, RunConfig
+from fehmtk.config import ModelConfig, RunConfig
 from fehmtk.fehm_objects import Grid
 from fehmtk.file_interface import read_grid, write_compact_node_data
 
-from .heat_flux_models import get_heatflux_models_by_kind
+from .boundary_models import get_boundary_model
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +30,11 @@ def generate_heat_flux_boundaries(config_file: Path, plot: bool = False):
     )
 
     logger.info('Computing boundary heat flux')
-    heatflux_by_node = compute_boundary_heatflux(grid, config.heat_flux_config)
+    heatflux_by_node = compute_boundary_heatflux(
+        grid=grid,
+        boundary_type='heat_flux',
+        model_config=config.heat_flux_config.heat_flux_model,
+    )
 
     logger.info(f'Writing heat flux to disk: {config.files_config.heat_flux}')
     write_compact_node_data(
@@ -43,16 +47,10 @@ def generate_heat_flux_boundaries(config_file: Path, plot: bool = False):
         plot_heatflux(heatflux_by_node, grid)
 
 
-def compute_boundary_heatflux(grid: Grid, heat_flux_config: HeatFluxConfig) -> dict[int, Decimal]:
-    heatflux_models = get_heatflux_models_by_kind()
-
-    try:
-        model = heatflux_models[heat_flux_config.heat_flux_model.kind]
-    except KeyError:
-        raise NotImplementedError(f'No model defined for kind {heat_flux_config.heat_flux_model.kind}')
-
+def compute_boundary_heatflux(*, grid: Grid, boundary_type: str, model_config: ModelConfig) -> dict[int, Decimal]:
+    model = get_boundary_model('heat_flux', model_config.kind)
     input_nodes = grid.get_nodes_in_outside_zone('bottom')
-    return {node.number: model(node, heat_flux_config.heat_flux_model.params) for node in input_nodes}
+    return {node.number: model(node, model_config.params) for node in input_nodes}
 
 
 def plot_heatflux(heatflux_by_node: dict[int, Decimal], grid: Grid):

--- a/test/end_to_end/test_written_files.py
+++ b/test/end_to_end/test_written_files.py
@@ -10,7 +10,7 @@ from fehmtk.config import RunConfig
 from fehmtk.file_interface import read_pressure, write_restart
 from fehmtk.preprocessors import (
     generate_flow_boundaries,
-    generate_input_heat_flux,
+    generate_heat_flux_boundaries,
     generate_hydrostatic_pressure,
     generate_rock_properties,
 )
@@ -82,11 +82,11 @@ def test_generate_flow_boundaries(tmp_path: Path, end_to_end_fixture_dir: Path, 
 
 
 @pytest.mark.parametrize('mesh_name', ('flat_box', 'outcrop_2d', 'warped_box'))
-def test_heat_in_against_fixture(tmp_path: Path, end_to_end_fixture_dir: Path, mesh_name: str):
+def test_heat_flux_against_fixture(tmp_path: Path, end_to_end_fixture_dir: Path, mesh_name: str):
     model_dir = end_to_end_fixture_dir / mesh_name / 'cond'
     config_file, (output_file,) = _setup_temporary_model_run(model_dir, tmp_path, output_keys=['heat_flux'])
 
-    generate_input_heat_flux(config_file)
+    generate_heat_flux_boundaries(config_file)
 
     fixture_file = model_dir / 'cond.hflx'
     assert output_file.read_text() == fixture_file.read_text()


### PR DESCRIPTION
Rename `heat_in` and related functions to `heat_flux` to unify the naming convention with how the `flow` command is used. This doesn't change any functionality, just naming.

Documentation will be updated for all commands at once, when this is done.