### PR TITLE
Flow models

### DIFF
--- a/fehmtk/preprocessors/boundary_models.py
+++ b/fehmtk/preprocessors/boundary_models.py
@@ -29,6 +29,10 @@ def _open_flow(node: Node, params: dict) -> tuple[Decimal]:
 
     Fluid input comes in at the specified temperature, output is at the in-place temperature. AIPED value sets the
     impedence to flow, and therefore determines the model's ability to maintain the desired pressure.
+
+    Required params:
+    input_fluid_temp_degC       (numeric)
+    aiped_to_volume_ratio       (numeric)
     """
     skd = '0'
     eflow = -params['input_fluid_temp_degC']

--- a/fehmtk/preprocessors/flow_boundaries.py
+++ b/fehmtk/preprocessors/flow_boundaries.py
@@ -74,9 +74,5 @@ def _validate_flow_config(config: FlowConfig):
         raise ValueError('No flow_config in config file.')
 
     for boundary_config in config.boundary_configs:
-        model = boundary_config.boundary_model
-        if model.kind not in ('open_flow'):
-            raise NotImplementedError(f'Boundary model kind ({model.kind}) not supported.')
-
         if not boundary_config.material_zones and not boundary_config.outside_zones:
             raise ValueError('No zones specified (outside or material), at least one zone is required.')

--- a/fehmtk/preprocessors/flow_boundaries.py
+++ b/fehmtk/preprocessors/flow_boundaries.py
@@ -4,7 +4,7 @@ import re
 from typing import Union
 import warnings
 
-from fehmtk.config import FlowConfig, RunConfig
+from fehmtk.config import BoundaryConfig, FlowConfig, HeatFluxConfig, RunConfig
 from fehmtk.fehm_objects import Grid, Node
 from fehmtk.file_interface import read_grid, write_compact_node_data
 
@@ -19,7 +19,7 @@ def generate_flow_boundaries(config_file: Path):
     if config.files_config.flow is None:
         raise ValueError(f'Flow file missing from files_config in RunConfig at {config_file}')
 
-    _validate_flow_config(config.flow_config)
+    _validate_config(config.flow_config)
 
     logger.info('Parsing grid into memory')
     grid = read_grid(
@@ -31,7 +31,11 @@ def generate_flow_boundaries(config_file: Path):
     )
 
     logger.info('Generating flow data')
-    flow_by_node = generate_flow_data_by_node_number(config.flow_config, grid)
+    flow_by_node = generate_boundary_data_by_node_number(
+        grid,
+        boundary_configs=config.flow_config.boundary_configs,
+        boundary_kind='flow',
+    )
     write_compact_node_data(
         flow_by_node,
         output_file=config.files_config.flow,
@@ -42,10 +46,15 @@ def generate_flow_boundaries(config_file: Path):
     warn_if_file_not_referenced(input_file=config.files_config.input, referenced_file=config.files_config.flow)
 
 
-def generate_flow_data_by_node_number(config: FlowConfig, grid: Grid) -> dict[int, float]:
+def generate_boundary_data_by_node_number(
+    grid: Grid,
+    *,
+    boundary_configs: list[BoundaryConfig],
+    boundary_kind: str,
+) -> dict[int, float]:
     flow_data_by_number = {}
-    for boundary_config in config.boundary_configs:
-        model = get_boundary_model('flow', boundary_config.boundary_model.kind)
+    for boundary_config in boundary_configs:
+        model = get_boundary_model(boundary_kind, boundary_config.boundary_model.kind)
         nodes = _gather_nodes(grid, boundary_config.outside_zones, boundary_config.material_zones)
         for node in nodes:
             flow_data_by_number[node.number] = model(node, boundary_config.boundary_model.params)
@@ -69,9 +78,9 @@ def warn_if_file_not_referenced(*, input_file: Path, referenced_file: Path):
         warnings.warn(f'Generated file {referenced_file.name} IS NOT REFERENCED in {input_file.name}.')
 
 
-def _validate_flow_config(config: FlowConfig):
+def _validate_config(config: Union[FlowConfig, HeatFluxConfig]):
     if config is None:
-        raise ValueError('No flow_config in config file.')
+        raise ValueError('No relevant boundary config (flow, heat_flux) found in config file.')
 
     for boundary_config in config.boundary_configs:
         if not boundary_config.material_zones and not boundary_config.outside_zones:

--- a/fehmtk/preprocessors/flow_boundaries.py
+++ b/fehmtk/preprocessors/flow_boundaries.py
@@ -8,6 +8,8 @@ from fehmtk.config import FlowConfig, RunConfig
 from fehmtk.fehm_objects import Grid, Node
 from fehmtk.file_interface import read_grid, write_compact_node_data
 
+from .boundary_models import get_boundary_model
+
 logger = logging.getLogger(__name__)
 
 
@@ -43,13 +45,11 @@ def generate_flow_boundaries(config_file: Path):
 def generate_flow_data_by_node_number(config: FlowConfig, grid: Grid) -> dict[int, float]:
     flow_data_by_number = {}
     for boundary_config in config.boundary_configs:
-        model = boundary_config.boundary_model
+        model = get_boundary_model('flow', boundary_config.boundary_model.kind)
         nodes = _gather_nodes(grid, boundary_config.outside_zones, boundary_config.material_zones)
         for node in nodes:
-            skd = '0'
-            eflow = -model.params['input_fluid_temp_degC']
-            aiped = abs(node.volume * model.params['aiped_to_volume_ratio'])
-            flow_data_by_number[node.number] = (skd, eflow, aiped)
+            flow_data_by_number[node.number] = model(node, boundary_config.boundary_model.params)
+
     return flow_data_by_number
 
 

--- a/test/utilities/test_flow_boundaries.py
+++ b/test/utilities/test_flow_boundaries.py
@@ -64,15 +64,3 @@ def test_validate_no_zones(valid_model_config):
     ])
     with pytest.raises(ValueError):
         _validate_flow_config(config)
-
-
-def test_validate_bad_model_kind(bad_model_config):
-    config = FlowConfig(boundary_configs=[
-        BoundaryConfig(
-            boundary_model=bad_model_config,
-            outside_zones=['top'],
-            material_zones=[1, 2],
-        )
-    ])
-    with pytest.raises(NotImplementedError):
-        _validate_flow_config(config)

--- a/test/utilities/test_flow_boundaries.py
+++ b/test/utilities/test_flow_boundaries.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from fehmtk.config import BoundaryConfig, FlowConfig, ModelConfig
-from fehmtk.preprocessors.flow_boundaries import _validate_flow_config, warn_if_file_not_referenced
+from fehmtk.preprocessors.flow_boundaries import _validate_config, warn_if_file_not_referenced
 
 
 @pytest.fixture
@@ -51,7 +51,7 @@ def test_warn_if_file_not_referenced_ok(fake_input_file: Path, recwarn):
 
 def test_validate_no_config():
     with pytest.raises(ValueError):
-        _validate_flow_config(None)
+        _validate_config(None)
 
 
 def test_validate_no_zones(valid_model_config):
@@ -63,4 +63,4 @@ def test_validate_no_zones(valid_model_config):
         )
     ])
     with pytest.raises(ValueError):
-        _validate_flow_config(config)
+        _validate_config(config)


### PR DESCRIPTION
This moves the `flow` command onto the same extendable system of "models" as `heat_flux`. This will enable others to add additional flow or heat_flux models easily in the same place in the future, and allows the two commands to share code.