### PR TITLE
Rename pressure config

### DIFF
--- a/fehmtk/config/__init__.py
+++ b/fehmtk/config/__init__.py
@@ -1,6 +1,6 @@
 from .boundary_config import BoundaryConfig, FlowConfig, HeatFluxConfig
 from .files_config import FilesConfig
 from .model_config import ModelConfig
-from .pressure_config import PressureConfig
+from .hydrostat_config import HydrostatConfig
 from .rock_properties_config import PropertyConfig, RockPropertiesConfig
 from .run_config import RunConfig

--- a/fehmtk/config/hydrostat_config.py
+++ b/fehmtk/config/hydrostat_config.py
@@ -5,7 +5,7 @@ from .model_config import ModelConfig
 
 
 @dataclass
-class PressureConfig:
+class HydrostatConfig:
     pressure_model: ModelConfig
     interpolation_model: ModelConfig = None
     sampling_model: Optional[ModelConfig] = None

--- a/fehmtk/config/run_config.py
+++ b/fehmtk/config/run_config.py
@@ -6,7 +6,7 @@ import yaml
 
 from .boundary_config import FlowConfig, HeatFluxConfig
 from .files_config import FilesConfig
-from .pressure_config import PressureConfig
+from .hydrostat_config import HydrostatConfig
 from .rock_properties_config import RockPropertiesConfig
 
 
@@ -17,7 +17,7 @@ class RunConfig:
     heat_flux_config: HeatFluxConfig
     rock_properties_config: RockPropertiesConfig
     flow_config: Optional[FlowConfig] = None
-    pressure_config: Optional[PressureConfig] = None
+    hydrostat_config: Optional[HydrostatConfig] = None
 
     @classmethod
     def from_dict(cls, dct: dict, files_relative_to: Optional[Path] = None):
@@ -26,7 +26,7 @@ class RunConfig:
             heat_flux_config=HeatFluxConfig.from_dict(dct['heat_flux_config']),
             rock_properties_config=RockPropertiesConfig.from_dict(dct['rock_properties_config']),
             flow_config=FlowConfig.from_dict(dct['flow_config']) if dct.get('flow_config') else None,
-            pressure_config=PressureConfig.from_dict(dct['pressure_config']) if dct.get('pressure_config') else None,
+            hydrostat_config=HydrostatConfig.from_dict(dct['hydrostat_config']) if dct.get('hydrostat_config') else None,
         )
 
     @classmethod

--- a/fehmtk/fehm_runs/create_config_for_legacy_run.py
+++ b/fehmtk/fehm_runs/create_config_for_legacy_run.py
@@ -94,7 +94,7 @@ def create_config_for_legacy_run(
 
     run_config = RunConfig(
         heat_flux_config=read_legacy_hfi_config(hfi_file),
-        pressure_config=read_legacy_ipi_config(ipi_file),
+        hydrostat_config=read_legacy_ipi_config(ipi_file),
         rock_properties_config=read_legacy_rpi_config(rpi_file),
         flow_config=flow_config,
         files_config=files_config,

--- a/fehmtk/file_interface/legacy_config/ipi_reader.py
+++ b/fehmtk/file_interface/legacy_config/ipi_reader.py
@@ -1,10 +1,10 @@
 from decimal import Decimal
 from pathlib import Path
 
-from fehmtk.config import ModelConfig, PressureConfig
+from fehmtk.config import ModelConfig, HydrostatConfig
 
 
-def read_legacy_ipi_config(ipi_file: Path) -> PressureConfig:
+def read_legacy_ipi_config(ipi_file: Path) -> HydrostatConfig:
     with open(ipi_file) as f:
         next(f)
         header = next(f).strip()
@@ -12,7 +12,7 @@ def read_legacy_ipi_config(ipi_file: Path) -> PressureConfig:
             raise ValueError(f'Unexpected header in {ipi_file}: "{header}"')
         z_interval = Decimal(next(f).strip())
         reference_z, reference_pressure, reference_temperature = [Decimal(v) for v in next(f).strip().split(',')]
-    return PressureConfig(
+    return HydrostatConfig(
         pressure_model=ModelConfig(
             kind='depth',
             params={

--- a/test/config/fixtures/flat_box_cond.yaml
+++ b/test/config/fixtures/flat_box_cond.yaml
@@ -25,7 +25,7 @@ heat_flux_config:
       params:
         constant: 3.67e-07
     outside_zones: ['bottom']
-pressure_config:
+hydrostat_config:
   pressure_model:
     kind: depth
     params:

--- a/test/config/fixtures/flat_box_config.yaml
+++ b/test/config/fixtures/flat_box_config.yaml
@@ -121,7 +121,7 @@ rock_properties_config:
           constant: 0.05
       zones: [3]
 
-pressure_config:
+hydrostat_config:
   pressure_model:
     kind: depth
     params:

--- a/test/config/test_config_objects.py
+++ b/test/config/test_config_objects.py
@@ -10,8 +10,8 @@ from fehmtk.config import (
     BoundaryConfig,
     FilesConfig,
     HeatFluxConfig,
+    HydrostatConfig,
     ModelConfig,
-    PressureConfig,
     PropertyConfig,
     RockPropertiesConfig,
     RunConfig,
@@ -52,7 +52,7 @@ def files_config_dict():
 
 
 @pytest.fixture
-def pressure_config_dict():
+def hydrostat_config_dict():
     return {
         'pressure_model': {
             'kind': 'depth',
@@ -147,7 +147,7 @@ def test_read_config(config_dict):
     config = RunConfig.from_dict(config_dict)
     assert isinstance(config.files_config, FilesConfig)
     assert isinstance(config.heat_flux_config, HeatFluxConfig)
-    assert isinstance(config.pressure_config, PressureConfig)
+    assert isinstance(config.hydrostat_config, HydrostatConfig)
     assert isinstance(config.rock_properties_config, RockPropertiesConfig)
 
 
@@ -176,7 +176,7 @@ def test_run_config_from_yaml(fixture_dir):
     config = RunConfig.from_yaml(fixture_dir / 'flat_box_cond.yaml')
     assert isinstance(config.files_config, FilesConfig)
     assert isinstance(config.heat_flux_config, HeatFluxConfig)
-    assert isinstance(config.pressure_config, PressureConfig)
+    assert isinstance(config.hydrostat_config, HydrostatConfig)
     assert isinstance(config.rock_properties_config, RockPropertiesConfig)
     assert config.files_config.grid == Path(fixture_dir / 'cond.fehm')
     assert config.files_config.flow is None
@@ -237,16 +237,16 @@ def test_heat_flux_config():
     )
 
 
-def test_pressure_config(pressure_config_dict):
-    config = PressureConfig.from_dict(pressure_config_dict)
+def test_hydrostat_config(hydrostat_config_dict):
+    config = HydrostatConfig.from_dict(hydrostat_config_dict)
     assert isinstance(config.pressure_model, ModelConfig)
     assert isinstance(config.interpolation_model, ModelConfig)
     assert isinstance(config.sampling_model, ModelConfig)
 
 
-def test_pressure_config_no_sampling(pressure_config_dict):
-    del pressure_config_dict['sampling_model']
-    config = PressureConfig.from_dict(pressure_config_dict)
+def test_hydrostat_config_no_sampling(hydrostat_config_dict):
+    del hydrostat_config_dict['sampling_model']
+    config = HydrostatConfig.from_dict(hydrostat_config_dict)
     assert isinstance(config.pressure_model, ModelConfig)
     assert isinstance(config.interpolation_model, ModelConfig)
     assert config.sampling_model is None

--- a/test/end_to_end/fixtures/flat_box/cond/config.yaml
+++ b/test/end_to_end/fixtures/flat_box/cond/config.yaml
@@ -29,7 +29,7 @@ heat_flux_config:
         crustal_age_sign: 1
         spread_rate_mm_per_year: 28.57
     outside_zones: ['bottom']
-pressure_config:
+hydrostat_config:
   pressure_model:
     kind: depth
     params:

--- a/test/end_to_end/fixtures/flat_box/p12/config.yaml
+++ b/test/end_to_end/fixtures/flat_box/p12/config.yaml
@@ -40,7 +40,7 @@ heat_flux_config:
         crustal_age_sign: 1
         spread_rate_mm_per_year: 28.57
     outside_zones: ['bottom']
-pressure_config:
+hydrostat_config:
   pressure_model:
     kind: depth
     params:

--- a/test/end_to_end/fixtures/outcrop_2d/cond/config.yaml
+++ b/test/end_to_end/fixtures/outcrop_2d/cond/config.yaml
@@ -25,7 +25,7 @@ heat_flux_config:
       params:
         constant: 3.67e-07
     outside_zones: ['bottom']
-pressure_config:
+hydrostat_config:
   pressure_model:
     kind: depth
     params:

--- a/test/end_to_end/fixtures/outcrop_2d/p13/config.yaml
+++ b/test/end_to_end/fixtures/outcrop_2d/p13/config.yaml
@@ -36,7 +36,7 @@ flow_config:
         input_fluid_temp_degC: 2
         aiped_to_volume_ratio: 1.0e-08
     outside_zones: ['top']
-pressure_config:
+hydrostat_config:
   pressure_model:
     kind: depth
     params:

--- a/test/end_to_end/fixtures/warped_box/cond/config.yaml
+++ b/test/end_to_end/fixtures/warped_box/cond/config.yaml
@@ -29,7 +29,7 @@ heat_flux_config:
         crustal_age_dimension: x
         spread_rate_mm_per_year: 10.0
     outside_zones: ['bottom']
-pressure_config:
+hydrostat_config:
   pressure_model:
     kind: depth
     params:

--- a/test/fehm_runs/test_create_run_from_mesh.py
+++ b/test/fehm_runs/test_create_run_from_mesh.py
@@ -123,7 +123,7 @@ def test_build_template_from_run_config():
         'heat_flux_config',
         'rock_properties_config',
         'flow_config',
-        'pressure_config',
+        'hydrostat_config',
     }
     assert template['heat_flux_config'] == {
         'boundary_configs': [


### PR DESCRIPTION
This renames the `PressureConfig` to `HydrostatConfig`, which matches the name of the command it pertains to. This is the last such config to update, and they now all match with their respective commands.