### PR TITLE
Command defaults

### DIFF
--- a/fehmtk/command_line_interface.py
+++ b/fehmtk/command_line_interface.py
@@ -2,6 +2,7 @@ import argparse
 import logging
 from pathlib import Path
 
+from .config import RunConfig
 from .fehm_runs import create_config_for_legacy_run, create_run_from_mesh, create_run_from_run
 from .preprocessors import (
     generate_flow_boundaries,
@@ -30,6 +31,14 @@ def entry_point():
 
     _func = args.pop('_func')
     _name = args.pop('_name')
+    config_file = args.get('config_file')
+    if config_file:
+        config = RunConfig.from_yaml(config_file)
+        command_defaults = (config.command_defaults or {}).get(_name, {})
+        for keyword, default_value in command_defaults.items():
+            if args.get(keyword) is None:
+                args[keyword] = default_value
+
     _func(**args)
 
 

--- a/fehmtk/config/run_config.py
+++ b/fehmtk/config/run_config.py
@@ -16,6 +16,7 @@ class RunConfig:
     files_config: FilesConfig
     heat_flux_config: HeatFluxConfig
     rock_properties_config: RockPropertiesConfig
+    command_defaults: dict = None
     flow_config: Optional[FlowConfig] = None
     hydrostat_config: Optional[HydrostatConfig] = None
 
@@ -25,6 +26,7 @@ class RunConfig:
             files_config=FilesConfig.from_dict(dct['files_config'], files_relative_to),
             heat_flux_config=HeatFluxConfig.from_dict(dct['heat_flux_config']),
             rock_properties_config=RockPropertiesConfig.from_dict(dct['rock_properties_config']),
+            command_defaults=dct.get('command_defaults'),
             flow_config=FlowConfig.from_dict(dct['flow_config']) if dct.get('flow_config') else None,
             hydrostat_config=HydrostatConfig.from_dict(dct['hydrostat_config']) if dct.get('hydrostat_config') else None,
         )

--- a/test/fehm_runs/test_create_run_from_mesh.py
+++ b/test/fehm_runs/test_create_run_from_mesh.py
@@ -119,6 +119,7 @@ def test_build_template_from_rock_properties_config():
 def test_build_template_from_run_config():
     template = build_template_from_type(RunConfig)
     assert template.keys() == {
+        'command_defaults',
         'files_config',
         'heat_flux_config',
         'rock_properties_config',


### PR DESCRIPTION
Allows setting default arguments for commands in the `config.yaml` file, as such:

```yaml
command_defaults:
  run_from_run:
    reset_zones:
    - top
```