### PR TITLE
Remove default append zones from run_from_mesh

### DIFF
--- a/fehmtk/command_line_interface.py
+++ b/fehmtk/command_line_interface.py
@@ -64,11 +64,7 @@ def add_fehmtk_subparsers(parser):
         '--append_zones',
         type=int_or_string,
         nargs='*',
-        help=(
-            'Space-separated list of zone names or numbers for outside zones to append to the material zone file. '
-            'Leave blank after --append_zones to skip this step. (default: top bottom)'
-        ),
-        default=('top', 'bottom'),
+        help='Space-separated list of zone names or numbers for outside zones to append to the material zone file.',
     )
     run_from_mesh.add_argument('--run_root', type=str, help='Common root to be used to name run files')
     run_from_mesh.add_argument('--grid_file', type=Path, help='Main grid (.fehm[n]) file')

--- a/fehmtk/fehm_runs/create_run_from_mesh.py
+++ b/fehmtk/fehm_runs/create_run_from_mesh.py
@@ -80,7 +80,10 @@ def create_run_from_mesh(
     create_template_run_config(template_files_config, output_file=target_directory / CONFIG_NAME)
 
     files_config = FilesConfig.from_dict(template_files_config)
+
+    logger.info('Writing files index to %s', target_directory / files_config.files.name)
     write_files_index(files_config, output_file=target_directory / files_config.files.name)
+
     create_template_input_file(files_config, output_file=target_directory / files_config.input.name)
     logger.info(
         'Suggested next steps:\n'


### PR DESCRIPTION
Drop the default to append zones from `run_from_mesh`. This is optional and shouldn't be the norm for most users. Adding this explicitly will be mentioned and described in the tutorial and explained in the docs. It will be easy to notice if forgotten, and can be done after the fact with the separate `append_zones` command.