### PR TITLE
Update config template

### DIFF
--- a/fehmtk/config/run_config.py
+++ b/fehmtk/config/run_config.py
@@ -14,9 +14,9 @@ from .rock_properties_config import RockPropertiesConfig
 class RunConfig:
     """Configuration defining a run and its components."""
     files_config: FilesConfig
-    heat_flux_config: HeatFluxConfig
     rock_properties_config: RockPropertiesConfig
-    command_defaults: dict = None
+    command_defaults: Optional[dict] = None
+    heat_flux_config: Optional[HeatFluxConfig] = None
     flow_config: Optional[FlowConfig] = None
     hydrostat_config: Optional[HydrostatConfig] = None
 
@@ -24,11 +24,15 @@ class RunConfig:
     def from_dict(cls, dct: dict, files_relative_to: Optional[Path] = None):
         return cls(
             files_config=FilesConfig.from_dict(dct['files_config'], files_relative_to),
-            heat_flux_config=HeatFluxConfig.from_dict(dct['heat_flux_config']),
             rock_properties_config=RockPropertiesConfig.from_dict(dct['rock_properties_config']),
             command_defaults=dct.get('command_defaults'),
+            heat_flux_config=(
+                HeatFluxConfig.from_dict(dct['heat_flux_config']) if dct.get('heat_flux_config') else None
+            ),
             flow_config=FlowConfig.from_dict(dct['flow_config']) if dct.get('flow_config') else None,
-            hydrostat_config=HydrostatConfig.from_dict(dct['hydrostat_config']) if dct.get('hydrostat_config') else None,
+            hydrostat_config=(
+                HydrostatConfig.from_dict(dct['hydrostat_config']) if dct.get('hydrostat_config') else None
+            ),
         )
 
     @classmethod

--- a/fehmtk/fehm_runs/create_run_from_mesh.py
+++ b/fehmtk/fehm_runs/create_run_from_mesh.py
@@ -117,10 +117,11 @@ def _generate_template_run_config(template_files_config: dict[str, Union[str, Pa
 def build_template_from_type(base_type: Type):
     optional = False
     if isinstance(base_type, _UnionGenericAlias):
-        types = set(base_type.__args__)
-        if type(None) in types:
+        types = base_type.__args__
+        NoneType = type(None)
+        if NoneType in types:
             optional = True
-            types.remove(type(None))
+            types = [t for t in types if not t == NoneType]
 
         if len(types) > 1:
             return f"TYPE__{'|'.join(_get_type_name(t) for t in types)}", optional

--- a/fehmtk/fehm_runs/create_run_from_mesh.py
+++ b/fehmtk/fehm_runs/create_run_from_mesh.py
@@ -114,7 +114,7 @@ def _generate_template_run_config(template_files_config: dict[str, Union[str, Pa
     return run_config_template
 
 
-def build_template_from_type(base_type: Type):
+def build_template_from_type(base_type: Type) -> tuple[dict, bool]:
     optional = False
     if isinstance(base_type, _UnionGenericAlias):
         types = base_type.__args__
@@ -147,7 +147,7 @@ def build_template_from_type(base_type: Type):
     return f'TYPE__{_get_type_name(base_type)}', optional
 
 
-def _get_type_name(base_type: Type):
+def _get_type_name(base_type: Type) -> str:
     try:
         return base_type.__name__
     except AttributeError:
@@ -229,7 +229,7 @@ def get_template_files_config(
     return template
 
 
-def _files_config_from_template(template_files_config: dict):
+def _files_config_from_template(template_files_config: dict) -> FilesConfig:
     config_dict = {}
     for key, value in template_files_config.items():
         (required_str, file_name) = key.split('__')

--- a/fehmtk/fehm_runs/create_run_from_mesh.py
+++ b/fehmtk/fehm_runs/create_run_from_mesh.py
@@ -161,8 +161,6 @@ def create_template_input_file(files_config: FilesConfig, output_file: Path):
         f.write('sol\n    -1    -1\n')
         f.write('ctrl\n    # ctrl config goes here\n')
         f.write('time\n    # time config goes here\n')
-        f.write('hflx\n    # hflx config for fixed temperature zones goes here\n')
-        f.write(f'hflx\nfile\n{files_config.heat_flux.name}\n')
         f.write(f'rock\nfile\n{files_config.rock_properties.name}\n')
         f.write(f'cond\nfile\n{files_config.conductivity.name}\n')
         f.write(f'perm\nfile\n{files_config.permeability.name}\n')

--- a/fehmtk/fehm_runs/create_run_from_mesh.py
+++ b/fehmtk/fehm_runs/create_run_from_mesh.py
@@ -79,7 +79,7 @@ def create_run_from_mesh(
     template_files_config = get_template_files_config(file_pairs_by_file_type, run_root)
     create_template_run_config(template_files_config, output_file=target_directory / CONFIG_NAME)
 
-    files_config = FilesConfig.from_dict(template_files_config)
+    files_config = _files_config_from_template(template_files_config)
 
     logger.info('Writing files index to %s', target_directory / files_config.files.name)
     write_files_index(files_config, output_file=target_directory / files_config.files.name)
@@ -228,3 +228,12 @@ def get_template_files_config(
             template[key] = f'{run_root}{EXT_BY_FILE[file_name]}' if run_root else f'{file_name}.txt'
 
     return template
+
+
+def _files_config_from_template(template_files_config: dict):
+    config_dict = {}
+    for key, value in template_files_config.items():
+        (required_str, file_name) = key.split('__')
+        if not value.startswith('TYPE__'):
+            config_dict[file_name] = value
+    return FilesConfig.from_dict(config_dict)

--- a/test/end_to_end/test_create_runs.py
+++ b/test/end_to_end/test_create_runs.py
@@ -109,8 +109,6 @@ def test_create_template_input_file(tmp_path):
         'sol\n    -1    -1\n'
         'ctrl\n    # ctrl config goes here\n'
         'time\n    # time config goes here\n'
-        'hflx\n    # hflx config for fixed temperature zones goes here\n'
-        f'hflx\nfile\n{files_config.heat_flux}\n'
         f'rock\nfile\n{files_config.rock_properties}\n'
         f'cond\nfile\n{files_config.conductivity}\n'
         f'perm\nfile\n{files_config.permeability}\n'

--- a/test/fehm_runs/test_create_run_from_mesh.py
+++ b/test/fehm_runs/test_create_run_from_mesh.py
@@ -5,7 +5,8 @@ from fehmtk.fehm_runs.create_run_from_mesh import build_template_from_type, get_
 
 
 def test_build_template_from_model_config():
-    template = build_template_from_type(ModelConfig)
+    (template, optional) = build_template_from_type(ModelConfig)
+    assert optional is False
     assert template == {'kind': 'replace__str', 'params': {}}
 
 
@@ -18,26 +19,27 @@ def test_get_template_files_config():
         run_root=None,
     )
     assert template == dict(
-        run_root='run',
-        material_zone='cond_material.zone',
-        outside_zone='outside_zone.txt',
-        area='cond.area',
-        rock_properties='rock_properties.txt',
-        conductivity='conductivity.txt',
-        pore_pressure='pore_pressure.txt',
-        permeability='permeability.txt',
-        files='fehmn.files',
-        grid='grid.txt',
-        input='input.txt',
-        output='output.txt',
-        storage='storage.txt',
-        history='history.txt',
-        water_properties='water_properties.txt',
-        check='check.txt',
-        error='error.txt',
-        final_conditions='final_conditions.txt',
-        flow='flow.txt',
-        heat_flux='heat_flux.txt',
+        REQUIRED__run_root='run',
+        REQUIRED__material_zone='cond_material.zone',
+        REQUIRED__outside_zone='outside_zone.txt',
+        REQUIRED__area='cond.area',
+        REQUIRED__rock_properties='rock_properties.txt',
+        REQUIRED__conductivity='conductivity.txt',
+        REQUIRED__pore_pressure='pore_pressure.txt',
+        REQUIRED__permeability='permeability.txt',
+        REQUIRED__files='fehmn.files',
+        REQUIRED__grid='grid.txt',
+        REQUIRED__input='input.txt',
+        REQUIRED__output='output.txt',
+        REQUIRED__storage='storage.txt',
+        REQUIRED__history='history.txt',
+        REQUIRED__water_properties='water_properties.txt',
+        REQUIRED__check='check.txt',
+        REQUIRED__error='error.txt',
+        REQUIRED__final_conditions='final_conditions.txt',
+        OPTIONAL__initial_conditions='TYPE__Path',
+        OPTIONAL__flow='TYPE__Path',
+        OPTIONAL__heat_flux='TYPE__Path',
     )
 
 
@@ -50,26 +52,27 @@ def test_get_template_files_config_run_root():
         run_root='my_run',
     )
     assert template == dict(
-        run_root='my_run',
-        material_zone='my_run_material.zone',
-        outside_zone='cond_outside.zone',
-        area='my_run.area',
-        rock_properties='my_run.rock',
-        conductivity='my_run.cond',
-        pore_pressure='my_run.ppor',
-        permeability='my_run.perm',
-        files='fehmn.files',
-        grid='cond.fehm',
-        input='my_run.dat',
-        output='my_run.out',
-        storage='my_run.stor',
-        history='my_run.hist',
-        water_properties='my_run.wpi',
-        check='my_run.chk',
-        error='my_run.err',
-        final_conditions='my_run.fin',
-        flow='my_run.flow',
-        heat_flux='my_run.hflx',
+        REQUIRED__run_root='my_run',
+        REQUIRED__material_zone='my_run_material.zone',
+        REQUIRED__outside_zone='cond_outside.zone',
+        REQUIRED__area='my_run.area',
+        REQUIRED__rock_properties='my_run.rock',
+        REQUIRED__conductivity='my_run.cond',
+        REQUIRED__pore_pressure='my_run.ppor',
+        REQUIRED__permeability='my_run.perm',
+        REQUIRED__files='fehmn.files',
+        REQUIRED__grid='cond.fehm',
+        REQUIRED__input='my_run.dat',
+        REQUIRED__output='my_run.out',
+        REQUIRED__storage='my_run.stor',
+        REQUIRED__history='my_run.hist',
+        REQUIRED__water_properties='my_run.wpi',
+        REQUIRED__check='my_run.chk',
+        REQUIRED__error='my_run.err',
+        REQUIRED__final_conditions='my_run.fin',
+        OPTIONAL__initial_conditions='TYPE__Path',
+        OPTIONAL__flow='TYPE__Path',
+        OPTIONAL__heat_flux='TYPE__Path',
     )
 
 
@@ -117,26 +120,27 @@ def test_build_template_from_rock_properties_config():
 
 
 def test_build_template_from_run_config():
-    template = build_template_from_type(RunConfig)
+    (template, optional) = build_template_from_type(RunConfig)
+    assert optional is False
     assert template.keys() == {
-        'command_defaults',
-        'files_config',
-        'heat_flux_config',
-        'rock_properties_config',
-        'flow_config',
-        'hydrostat_config',
+        'OPTIONAL__command_defaults',
+        'REQUIRED__files_config',
+        'OPTIONAL__heat_flux_config',
+        'REQUIRED__rock_properties_config',
+        'OPTIONAL__flow_config',
+        'OPTIONAL__hydrostat_config',
     }
-    assert template['heat_flux_config'] == {
-        'boundary_configs': [
+    assert template['OPTIONAL__heat_flux_config'] == {
+        'REQUIRED__boundary_configs': [
             {
-                'boundary_model': {'kind': 'replace__str', 'params': {}},
-                'material_zones': 'replace__list|NoneType',
-                'outside_zones': 'replace__list|NoneType',
+                'REQUIRED__boundary_model': {'REQUIRED__kind': 'TYPE__str', 'REQUIRED__params': {}},
+                'OPTIONAL__material_zones': ['TYPE__str|int'],
+                'OPTIONAL__outside_zones': ['TYPE__str|int'],
             },
         ],
     }
-    for key, value in template['files_config'].items():
-        if key == 'run_root':
-            assert value == 'replace__str'
+    for key, value in template['REQUIRED__files_config'].items():
+        if key == 'REQUIRED__run_root':
+            assert value == 'TYPE__str'
         else:
-            assert value in ('replace__Path', 'replace__Path|NoneType')
+            assert value == 'TYPE__Path'

--- a/test/fehm_runs/test_create_run_from_mesh.py
+++ b/test/fehm_runs/test_create_run_from_mesh.py
@@ -7,7 +7,7 @@ from fehmtk.fehm_runs.create_run_from_mesh import build_template_from_type, get_
 def test_build_template_from_model_config():
     (template, optional) = build_template_from_type(ModelConfig)
     assert optional is False
-    assert template == {'kind': 'replace__str', 'params': {}}
+    assert template == {'REQUIRED__kind': 'TYPE__str', 'REQUIRED__params': {}}
 
 
 def test_get_template_files_config():
@@ -77,43 +77,44 @@ def test_get_template_files_config_run_root():
 
 
 def test_build_template_from_rock_properties_config():
-    template = build_template_from_type(RockPropertiesConfig)
+    template, optional = build_template_from_type(RockPropertiesConfig)
+    assert optional is False
     assert template == {
-        'zone_assignment_order': ['replace__int|str'],
-        'compressibility_configs': [
+        'REQUIRED__zone_assignment_order': ['TYPE__str|int'],
+        'REQUIRED__compressibility_configs': [
             {
-                'property_model': {'kind': 'replace__str', 'params': {}},
-                'zones': ['replace__int|str']
+                'REQUIRED__property_model': {'REQUIRED__kind': 'TYPE__str', 'REQUIRED__params': {}},
+                'REQUIRED__zones': ['TYPE__str|int']
             },
         ],
-        'conductivity_configs': [
+        'REQUIRED__conductivity_configs': [
             {
-                'property_model': {'kind': 'replace__str', 'params': {}},
-                'zones': ['replace__int|str']
+                'REQUIRED__property_model': {'REQUIRED__kind': 'TYPE__str', 'REQUIRED__params': {}},
+                'REQUIRED__zones': ['TYPE__str|int']
             },
         ],
-        'permeability_configs': [
+        'REQUIRED__permeability_configs': [
             {
-                'property_model': {'kind': 'replace__str', 'params': {}},
-                'zones': ['replace__int|str']
+                'REQUIRED__property_model': {'REQUIRED__kind': 'TYPE__str', 'REQUIRED__params': {}},
+                'REQUIRED__zones': ['TYPE__str|int']
             },
         ],
-        'grain_density_configs': [
+        'REQUIRED__grain_density_configs': [
             {
-                'property_model': {'kind': 'replace__str', 'params': {}},
-                'zones': ['replace__int|str']
+                'REQUIRED__property_model': {'REQUIRED__kind': 'TYPE__str', 'REQUIRED__params': {}},
+                'REQUIRED__zones': ['TYPE__str|int']
             },
         ],
-        'specific_heat_configs': [
+        'REQUIRED__specific_heat_configs': [
             {
-                'property_model': {'kind': 'replace__str', 'params': {}},
-                'zones': ['replace__int|str']
+                'REQUIRED__property_model': {'REQUIRED__kind': 'TYPE__str', 'REQUIRED__params': {}},
+                'REQUIRED__zones': ['TYPE__str|int']
             },
         ],
-        'porosity_configs': [
+        'REQUIRED__porosity_configs': [
             {
-                'property_model': {'kind': 'replace__str', 'params': {}},
-                'zones': ['replace__int|str']
+                'REQUIRED__property_model': {'REQUIRED__kind': 'TYPE__str', 'REQUIRED__params': {}},
+                'REQUIRED__zones': ['TYPE__str|int']
             },
         ],
     }

--- a/test/fehm_runs/test_create_run_from_mesh.py
+++ b/test/fehm_runs/test_create_run_from_mesh.py
@@ -80,41 +80,41 @@ def test_build_template_from_rock_properties_config():
     template, optional = build_template_from_type(RockPropertiesConfig)
     assert optional is False
     assert template == {
-        'REQUIRED__zone_assignment_order': ['TYPE__str|int'],
+        'REQUIRED__zone_assignment_order': ['TYPE__int|str'],
         'REQUIRED__compressibility_configs': [
             {
                 'REQUIRED__property_model': {'REQUIRED__kind': 'TYPE__str', 'REQUIRED__params': {}},
-                'REQUIRED__zones': ['TYPE__str|int']
+                'REQUIRED__zones': ['TYPE__int|str']
             },
         ],
         'REQUIRED__conductivity_configs': [
             {
                 'REQUIRED__property_model': {'REQUIRED__kind': 'TYPE__str', 'REQUIRED__params': {}},
-                'REQUIRED__zones': ['TYPE__str|int']
+                'REQUIRED__zones': ['TYPE__int|str']
             },
         ],
         'REQUIRED__permeability_configs': [
             {
                 'REQUIRED__property_model': {'REQUIRED__kind': 'TYPE__str', 'REQUIRED__params': {}},
-                'REQUIRED__zones': ['TYPE__str|int']
+                'REQUIRED__zones': ['TYPE__int|str']
             },
         ],
         'REQUIRED__grain_density_configs': [
             {
                 'REQUIRED__property_model': {'REQUIRED__kind': 'TYPE__str', 'REQUIRED__params': {}},
-                'REQUIRED__zones': ['TYPE__str|int']
+                'REQUIRED__zones': ['TYPE__int|str']
             },
         ],
         'REQUIRED__specific_heat_configs': [
             {
                 'REQUIRED__property_model': {'REQUIRED__kind': 'TYPE__str', 'REQUIRED__params': {}},
-                'REQUIRED__zones': ['TYPE__str|int']
+                'REQUIRED__zones': ['TYPE__int|str']
             },
         ],
         'REQUIRED__porosity_configs': [
             {
                 'REQUIRED__property_model': {'REQUIRED__kind': 'TYPE__str', 'REQUIRED__params': {}},
-                'REQUIRED__zones': ['TYPE__str|int']
+                'REQUIRED__zones': ['TYPE__int|str']
             },
         ],
     }
@@ -135,8 +135,8 @@ def test_build_template_from_run_config():
         'REQUIRED__boundary_configs': [
             {
                 'REQUIRED__boundary_model': {'REQUIRED__kind': 'TYPE__str', 'REQUIRED__params': {}},
-                'OPTIONAL__material_zones': ['TYPE__str|int'],
-                'OPTIONAL__outside_zones': ['TYPE__str|int'],
+                'OPTIONAL__material_zones': ['TYPE__int|str'],
+                'OPTIONAL__outside_zones': ['TYPE__int|str'],
             },
         ],
     }


### PR DESCRIPTION
Update config template generated by `run_from_mesh` to include more information about required vs. optional keys, and to expand optional configs to a greater degree.

This also makes `command_defaults` and `heat_flux` configs optional, which should have been the case already.