### PR TITLE
Add rsti to fehmn.files output when ini exists

### DIFF
--- a/fehmtk/file_interface/files_index.py
+++ b/fehmtk/file_interface/files_index.py
@@ -16,11 +16,21 @@ FILES_INDEX_KEY_MAPPING = {
     'history': 'hist',
 }
 
+OPTIONAL_KEYS_MAPPING = {
+    'initial_conditions': 'rsti',
+}
+
 
 def write_files_index(files_config: FilesConfig, output_file: Path):
     files_config_relative_to_output = files_config.relative_to(output_file.parent)
 
     with open(output_file, 'w') as f:
         for config_key, files_index_key in FILES_INDEX_KEY_MAPPING.items():
-            f.write(f'{files_index_key}: {getattr(files_config_relative_to_output, config_key)}\n')
+            file_path = getattr(files_config_relative_to_output, config_key)
+            f.write(f'{files_index_key}: {file_path}\n')
+        for config_key, files_index_key in OPTIONAL_KEYS_MAPPING.items():
+            file_path = getattr(files_config_relative_to_output, config_key)
+            if file_path is not None:
+                f.write(f'{files_index_key}: {file_path}\n')
+
         f.write('\nall')

--- a/test/end_to_end/test_create_runs.py
+++ b/test/end_to_end/test_create_runs.py
@@ -47,6 +47,8 @@ def test_create_run_from_mesh_flat_box_infer_run_root(tmp_path, end_to_end_fixtu
         'fehmn.files',
         'new_run.dat',
     }
+    assert 'rsti:' not in (new_directory / 'fehmn.files').read_text()
+
 
 
 def test_create_run_from_mesh_outcrop_explicit_files(tmp_path, end_to_end_fixture_dir):
@@ -139,6 +141,8 @@ def test_create_run_from_run(tmp_path, end_to_end_fixture_dir):
     assert new_config.files_config.grid.exists()
     assert new_config.files_config.storage.exists()
     assert new_config.files_config.files.exists()
+
+    assert 'rsti: cond.ini' in new_config.files_config.files.read_text()
 
     assert new_config.files_config.input.exists()
     input_content = new_config.files_config.input.read_text()


### PR DESCRIPTION
This adds the `rsti:` line to `files` output when `initial_conditions` are specified. This also resolves a bug in the tutorial.